### PR TITLE
Refactor/#5 - 그룹 세팅 페이지 로직, 스타일 분리

### DIFF
--- a/src/components/common/errorMessage/ErrorMessage.tsx
+++ b/src/components/common/errorMessage/ErrorMessage.tsx
@@ -1,0 +1,9 @@
+interface ErrorMessageProps {
+  message: string;
+}
+
+const ErrorMessage: React.FC<ErrorMessageProps> = ({ message }) => {
+  return <p className='text-main font-caption'>{message}</p>;
+};
+
+export default ErrorMessage;

--- a/src/components/setting/groupSetting/PresetSettingBtn/PresetSettingBtn.tsx
+++ b/src/components/setting/groupSetting/PresetSettingBtn/PresetSettingBtn.tsx
@@ -1,0 +1,20 @@
+import { ArrowRightIcon } from '@/components/common/icon';
+import { Button } from '@/components/common/ui/button';
+
+interface PresetSettingBtnProps {
+  handleClick: () => void;
+}
+
+const PresetSettingBtn: React.FC<PresetSettingBtnProps> = ({ handleClick }) => {
+  return (
+    <div className='flex flex-col gap-2 pb-6'>
+      <p className='text-black font-label'>프리셋 관리</p>
+      <Button variant='group' size='large' onClick={handleClick} className='!justify-between px-2'>
+        <p className='text-gray1 font-body'>프리셋 수정하기</p>
+        <ArrowRightIcon className='text-main' />
+      </Button>
+    </div>
+  );
+};
+
+export default PresetSettingBtn;

--- a/src/hooks/useGroupSetting.ts
+++ b/src/hooks/useGroupSetting.ts
@@ -1,0 +1,136 @@
+import { useState, useEffect } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { User } from '@/types/apis/groupApi';
+import { getGroupUser } from '@/services/group/getGroupUser';
+import { postBanUser } from '@/services/group/postBanUser';
+import { deleteGroupUser } from '@/services/group/deleteGroupUser';
+import { putChangeGroupName } from '@/services/group/putChangeGroupName';
+import { toast } from '@/hooks/use-toast';
+import { INPUT_VALIDATION } from '@/constants/validation';
+
+const useGroupSetting = () => {
+  const navigate = useNavigate();
+  const { channelId: strChannelId } = useParams();
+  const channelId = Number(strChannelId);
+
+  const [groupName, setGroupName] = useState('');
+  const [isEdited, setIsEdited] = useState(false);
+  const [isOpen, setIsOpen] = useState(false);
+  const [sheetTitle, setSheetTitle] = useState('');
+  const [btnText, setBtnText] = useState('');
+  const [currentUser, setCurrentUser] = useState<User | null>(null);
+  const [members, setMembers] = useState<User[]>([]);
+  const [selectedMember, setSelectedMember] = useState<User | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<boolean>(false);
+
+  useEffect(() => {
+    const fetchGroupMembers = async () => {
+      try {
+        const response = await getGroupUser({ channelId });
+        setGroupName(response.result.name);
+        setMembers(response.result.userList);
+        const current = response.result.userList.find(user => user.currentUser);
+        setCurrentUser(current || null);
+        setIsLoading(false);
+      } catch (error) {
+        console.error('멤버 조회 실패:', error);
+        setIsLoading(false);
+      }
+    };
+
+    fetchGroupMembers();
+  }, []);
+
+  const handleMovePreset = () => {
+    navigate(`/group-setting/${channelId}/preset-setting`);
+  };
+
+  const handleGroupNameChange = (value: string) => {
+    setGroupName(value);
+    setIsEdited(value !== groupName);
+    if (
+      value.length <= INPUT_VALIDATION.roomName.maxLength &&
+      INPUT_VALIDATION.roomName.regexp.test(value)
+    ) {
+      setError(false);
+    } else {
+      setError(true);
+    }
+  };
+
+  const handleDone = async () => {
+    await putChangeGroupName({
+      channelId: channelId,
+      name: groupName,
+    });
+    setIsEdited(false);
+    toast({
+      title: '그룹 이름이 변경되었어요',
+    });
+  };
+
+  const handleSheet = (member: User) => {
+    setSelectedMember(member);
+    const isCurrentUserSelected = member.currentUser;
+    if (isAdmin && isCurrentUserSelected) {
+      setBtnText('나갈래요');
+      setSheetTitle(`${groupName}에서 정말 나가시겠습니까?`);
+    } else if (isAdmin) {
+      setBtnText('내보낼래요');
+      setSheetTitle(`${member.nickName}님을 내보내시겠습니까?`);
+    } else {
+      setBtnText('나갈래요');
+      setSheetTitle(`${groupName}에서 정말 나가시겠습니까?`);
+    }
+    setIsOpen(true);
+  };
+
+  const handleExit = async (member: User) => {
+    try {
+      const isCurrentUserSelected = member.currentUser;
+
+      if (isAdmin && !isCurrentUserSelected) {
+        await postBanUser({ channelId, email: member.email });
+        setMembers(prev => prev.filter(m => m.email !== member.email));
+        toast({ title: '탈퇴되었습니다' });
+      } else {
+        await deleteGroupUser({ channelId });
+        navigate('/group-select');
+      }
+
+      setIsOpen(false);
+    } catch (error) {
+      console.error('멤버 방출/그룹 나가기 실패:', error);
+    }
+  };
+
+  const handleClose = () => {
+    setIsOpen(false);
+  };
+
+  const isAdmin = currentUser?.role === 'ADMIN';
+
+  return {
+    groupName,
+    isEdited,
+    isOpen,
+    sheetTitle,
+    btnText,
+    currentUser,
+    members,
+    selectedMember,
+    isLoading,
+    error,
+    isAdmin,
+    handleMovePreset,
+    handleGroupNameChange,
+    handleDone,
+    handleSheet,
+    handleExit,
+    handleClose,
+    setIsOpen,
+  };
+};
+
+export default useGroupSetting;

--- a/src/pages/group/GroupSettingPage.tsx
+++ b/src/pages/group/GroupSettingPage.tsx
@@ -1,133 +1,34 @@
 import SettingHeaderContainer from '@/components/common/header/Header';
-import { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
 import InputWithLabel from '@/components/common/input/InputWithLabel';
 import MemberItems from '@/components/setting/groupSetting/MemberItems/MemberItems';
 import InviteLinkWithLabel from '@/components/setting/groupSetting/InviteLink/InviteLinkWithLabel';
 import ExitSheet from '@/components/setting/ExitSheet/ExitSheet';
-import { getGroupUser } from '@/services/group/getGroupUser';
-import { User } from '@/types/apis/groupApi';
-import { postBanUser } from '@/services/group/postBanUser';
-import { deleteGroupUser } from '@/services/group/deleteGroupUser';
-import { putChangeGroupName } from '@/services/group/putChangeGroupName';
-import { toast } from '@/hooks/use-toast';
-import { useParams } from 'react-router-dom';
-import { ArrowRightIcon } from '@/components/common/icon';
-import { Button } from '@/components/common/ui/button';
 import { INPUT_VALIDATION } from '@/constants/validation';
+import useGroupSetting from '@/hooks/useGroupSetting';
+import PresetSettingBtn from '@/components/setting/groupSetting/PresetSettingBtn/PresetSettingBtn';
+import ErrorMessage from '@/components/common/errorMessage/ErrorMessage';
 
 const GroupSettingPage = () => {
-  const navigate = useNavigate();
-  const { channelId: strChannelId } = useParams();
-
-  const [groupName, setGroupName] = useState('');
-  const [isEdited, setIsEdited] = useState(false);
-  const [isOpen, setIsOpen] = useState(false);
-
-  const [sheetTitle, setSheetTitle] = useState('');
-  const [btnText, setBtnText] = useState('');
-
-  const [currentUser, setCurrentUser] = useState<User | null>(null);
-  const [members, setMembers] = useState<User[]>([]);
-
-  const [selectedMember, setSelectedMember] = useState<User | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
-
-  const [error, setError] = useState<boolean>(false);
-
-  const channelId = Number(strChannelId);
-
-  useEffect(() => {
-    const fetchGroupMembers = async () => {
-      try {
-        const response = await getGroupUser({ channelId });
-
-        setGroupName(response.result.name);
-        setMembers(response.result.userList);
-        const current = response.result.userList.find(user => user.currentUser);
-        setCurrentUser(current || null);
-        setIsLoading(false);
-      } catch (error) {
-        console.error('멤버 조회 실패:', error);
-        setIsLoading(false);
-      }
-    };
-
-    fetchGroupMembers();
-  }, []);
-
-  const handleMovePreset = () => {
-    navigate(`/group-setting/${channelId}/preset-setting`);
-  };
-
-  const handleGroupNameChange = (value: string) => {
-    setGroupName(value);
-    setIsEdited(value !== groupName);
-    if (
-      value.length <= INPUT_VALIDATION.roomName.maxLength &&
-      INPUT_VALIDATION.roomName.regexp.test(value)
-    ) {
-      setError(false);
-    } else {
-      setError(true);
-    }
-  };
-
-  const handleDone = async () => {
-    await putChangeGroupName({
-      channelId: channelId,
-      name: groupName,
-    });
-
-    setIsEdited(false);
-    toast({
-      title: '그룹 이름이 변경되었어요',
-    });
-  };
-
-  const isAdmin = currentUser?.role === 'ADMIN';
-
-  // 바텀시트 문구 체크
-  const handleSheet = (member: User) => {
-    setSelectedMember(member); // 선택된 멤버 저장
-    const isCurrentUserSelected = member.currentUser;
-    if (isAdmin && isCurrentUserSelected) {
-      setBtnText('나갈래요');
-      setSheetTitle(`${groupName}에서 정말 나가시겠습니까?`);
-    } else if (isAdmin) {
-      setBtnText('내보낼래요');
-      setSheetTitle(`${member.nickName}님을 내보내시겠습니까?`);
-    } else {
-      setBtnText('나갈래요');
-      setSheetTitle(`${groupName}에서 정말 나가시겠습니까?`);
-    }
-    setIsOpen(true);
-  };
-
-  // 멤버 방출 or 나가기 처리
-  const handleExit = async (member: User) => {
-    try {
-      const isCurrentUserSelected = member.currentUser;
-
-      if (isAdmin && !isCurrentUserSelected) {
-        await postBanUser({ channelId, email: member.email });
-        setMembers(prev => prev.filter(m => m.email !== member.email));
-        toast({ title: '탈퇴되었습니다' });
-      } else {
-        await deleteGroupUser({ channelId });
-        navigate('/group-select');
-      }
-
-      setIsOpen(false);
-    } catch (error) {
-      console.error('멤버 방출/그룹 나가기 실패:', error);
-    }
-  };
-
-  // 바텀시트 닫기
-  const handleClose = () => {
-    setIsOpen(false);
-  };
+  const {
+    groupName,
+    isEdited,
+    isOpen,
+    sheetTitle,
+    btnText,
+    currentUser,
+    members,
+    selectedMember,
+    isLoading,
+    error,
+    isAdmin,
+    handleMovePreset,
+    handleGroupNameChange,
+    handleDone,
+    handleSheet,
+    handleExit,
+    handleClose,
+    setIsOpen,
+  } = useGroupSetting();
 
   if (isLoading) {
     return <div></div>;
@@ -150,9 +51,7 @@ const GroupSettingPage = () => {
             disabled={!isAdmin}
             handleChange={handleGroupNameChange}
           />
-          {error && (
-            <p className='text-main font-caption'>{INPUT_VALIDATION.roomName.errorMessage}</p>
-          )}
+          {error && <ErrorMessage message={INPUT_VALIDATION.roomName.errorMessage} />}
         </div>
         <MemberItems
           leader={isAdmin}
@@ -161,18 +60,7 @@ const GroupSettingPage = () => {
           handleClick={handleSheet}
         />
         <InviteLinkWithLabel />
-        <div className='flex flex-col gap-2 pb-6'>
-          <p className='text-black font-label'>프리셋 관리</p>
-          <Button
-            variant='group'
-            size='large'
-            onClick={handleMovePreset}
-            className='!justify-between px-2'
-          >
-            <p className='text-gray1 font-body'>프리셋 수정하기</p>
-            <ArrowRightIcon className='text-main' />
-          </Button>
-        </div>
+        <PresetSettingBtn handleClick={handleMovePreset} />
       </div>
       <ExitSheet
         sheetTitle={sheetTitle}


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

> 그룹 세팅 페이지 로직, 스타일 분리

## 📌 이슈 넘버

> #5

## 📝 작업 내용
- errorMessage 공통 컴포넌트 추가
- 로직 분리 hook 추가
- 스타일 분리 PresetSettingBtn 컴포넌트 추가
- groupSettingPage 리팩토링

## 📸 스크린샷(선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
