### PR TITLE
Feature/#11-랜딩 페이지 로직, 스타일 분리

### DIFF
--- a/src/components/landing/KakaoLoginButton.tsx
+++ b/src/components/landing/KakaoLoginButton.tsx
@@ -1,0 +1,33 @@
+import { motion } from 'framer-motion';
+import Button from '@/components/common/button/Button/Button';
+
+interface KakaoLoginButtonProps {
+  handleLoginButton: () => void;
+}
+
+const KakaoLoginButton: React.FC<KakaoLoginButtonProps> = ({ handleLoginButton }) => {
+  const item = {
+    hidden: { opacity: 0, y: 0 },
+    show: {
+      opacity: 1,
+      y: 0,
+      transition: {
+        duration: 0.5,
+        ease: 'easeIn',
+      },
+    },
+  };
+
+  return (
+    <motion.section variants={item} aria-label='카카오 로그인 버튼' className='sticky bottom-6'>
+      <Button
+        label='카카오로 3초만에 시작하기'
+        variant='kakao'
+        size='large'
+        handleClick={handleLoginButton}
+      />
+    </motion.section>
+  );
+};
+
+export default KakaoLoginButton;

--- a/src/components/landing/ServiceLogo.tsx
+++ b/src/components/landing/ServiceLogo.tsx
@@ -1,0 +1,26 @@
+import { motion } from 'framer-motion';
+import LottieIcon from '@/components/common/lottie/LottieIcon';
+
+const ServiceLogo = () => {
+  const item = {
+    hidden: { opacity: 0, y: 0 },
+    show: {
+      opacity: 1,
+      y: 0,
+      transition: {
+        duration: 0.5,
+        ease: 'easeIn',
+      },
+    },
+  };
+
+  return (
+    <motion.section variants={item} aria-label='서비스 로고' className='relative flex-1'>
+      <div className='absolute left-1/2 top-1/2 h-full w-full -translate-x-1/2 -translate-y-1/2'>
+        <LottieIcon />
+      </div>
+    </motion.section>
+  );
+};
+
+export default ServiceLogo;

--- a/src/components/landing/ServiceTitle.tsx
+++ b/src/components/landing/ServiceTitle.tsx
@@ -1,0 +1,31 @@
+import { motion } from 'framer-motion';
+import LogoIcon from '@/components/common/icon/LogoIcon';
+
+const ServiceTitle = () => {
+  const item = {
+    hidden: { opacity: 0, y: 0 },
+    show: {
+      opacity: 1,
+      y: 0,
+      transition: {
+        duration: 0.5,
+        ease: 'easeIn',
+      },
+    },
+  };
+
+  return (
+    <section aria-label='서비스 이름'>
+      <div className='flex flex-col items-center justify-center gap-6 pt-20 text-24 font-bold'>
+        <motion.p className='flex justify-center text-sub font-label' variants={item}>
+          함께라서 더 즐거운 집안일
+        </motion.p>
+        <motion.div variants={item}>
+          <LogoIcon />
+        </motion.div>
+      </div>
+    </section>
+  );
+};
+
+export default ServiceTitle;

--- a/src/components/landing/index.ts
+++ b/src/components/landing/index.ts
@@ -1,0 +1,3 @@
+export { default as ServiceTitle } from './ServiceTitle';
+export { default as ServiceLogo } from './ServiceLogo';
+export { default as KakaoLoginButton } from './KakaoLoginButton';

--- a/src/hooks/useLanding.ts
+++ b/src/hooks/useLanding.ts
@@ -1,0 +1,34 @@
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { getMyInitState } from '@/services/user/getMyInitState';
+
+export const useLanding = () => {
+  const navigate = useNavigate();
+
+  const handleLoginButton = () => {
+    if (localStorage.getItem('access_token')) {
+      navigate('/group-select');
+      return;
+    }
+    window.location.href = `${import.meta.env.VITE_SERVER_URL}/oauth2/authorization/kakao`;
+  };
+
+  useEffect(() => {
+    const checkInitialState = async () => {
+      const accessToken = new URLSearchParams(location.search).get('access_token');
+      if (accessToken) {
+        localStorage.setItem('access_token', accessToken);
+        try {
+          const initState = await getMyInitState();
+          initState.result ? navigate('/group-select') : navigate('/register');
+        } catch (error) {
+          console.error('초기 상태 확인 실패:', error);
+        }
+      }
+    };
+
+    checkInitialState();
+  }, [navigate]);
+
+  return { handleLoginButton };
+};

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -1,13 +1,10 @@
-import Button from '@/components/common/button/Button/Button';
-import { getMyInitState } from '@/services/user/getMyInitState';
-import { useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
-import LottieIcon from '@/components/common/lottie/LottieIcon';
-import LogoIcon from '@/components/common/icon/LogoIcon';
 import { motion } from 'framer-motion';
+import { ServiceTitle, ServiceLogo, KakaoLoginButton } from '@/components/landing';
+import { useLanding } from '@/hooks/useLanding';
 
 const LandingPage = () => {
-  const navigate = useNavigate();
+  const { handleLoginButton } = useLanding();
+
   const container = {
     hidden: { opacity: 0 },
     show: {
@@ -18,43 +15,6 @@ const LandingPage = () => {
     },
   };
 
-  const item = {
-    hidden: { opacity: 0, y: 0 },
-    show: {
-      opacity: 1,
-      y: 0,
-      transition: {
-        duration: 0.5,
-        ease: 'easeIn',
-      },
-    },
-  };
-
-  const handleLoginButton = () => {
-    if (localStorage.getItem('access_token')) {
-      navigate('/group-select');
-      return;
-    }
-    window.location.href = `${import.meta.env.VITE_SERVER_URL}/oauth2/authorization/kakao`;
-  };
-
-  useEffect(() => {
-    const checkInitialState = async () => {
-      const accessToken = new URLSearchParams(location.search).get('access_token');
-      if (accessToken) {
-        localStorage.setItem('access_token', accessToken);
-        try {
-          const initState = await getMyInitState();
-          initState.result ? navigate('/group-select') : navigate('/register');
-        } catch (error) {
-          console.error('초기 상태 확인 실패:', error);
-        }
-      }
-    };
-
-    checkInitialState();
-  }, []);
-
   return (
     <motion.div
       className={`mx-auto flex h-screen flex-col gap-10 px-5 text-center`}
@@ -63,30 +23,10 @@ const LandingPage = () => {
       animate='show'
     >
       <div className='flex flex-1 flex-col'>
-        <section aria-label='서비스 이름'>
-          <div className='flex flex-col items-center justify-center gap-6 pt-20 text-24 font-bold'>
-            <motion.p className='flex justify-center text-sub font-label' variants={item}>
-              함께라서 더 즐거운 집안일
-            </motion.p>
-            <motion.div variants={item}>
-              <LogoIcon />
-            </motion.div>
-          </div>
-        </section>
-        <motion.section variants={item} aria-label='서비스 로고' className='relative flex-1'>
-          <div className='absolute left-1/2 top-1/2 h-full w-full -translate-x-1/2 -translate-y-1/2'>
-            <LottieIcon />
-          </div>
-        </motion.section>
+        <ServiceTitle />
+        <ServiceLogo />
       </div>
-      <motion.section variants={item} aria-label='카카오 로그인 버튼' className='sticky bottom-6'>
-        <Button
-          label='카카오로 3초만에 시작하기'
-          variant='kakao'
-          size='large'
-          handleClick={handleLoginButton}
-        />
-      </motion.section>
+      <KakaoLoginButton handleLoginButton={handleLoginButton} />
     </motion.div>
   );
 };


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

> 랜딩 페이지 - 로직 스타일, 분리

## 📌 이슈 넘버

- #3 
- #11 

## 📝 작업 내용
- ServiceTtitle, ServiceLogo, KakaoLoginButton 컴포넌트로 분리
- 세부 로직을 훅으로 분리
- import 정리

## 📸 스크린샷(선택)

## 💬리뷰 요구사항(선택)

> 수정할 사항 있으면 말씀해주세요
