### PR TITLE
Feature/#16-공통 에러처리 적용 및 관련 로직 리팩토링

### DIFF
--- a/src/components/home/WeeklyDate/WeeklyDate.tsx
+++ b/src/components/home/WeeklyDate/WeeklyDate.tsx
@@ -56,26 +56,30 @@ const WeeklyDate = () => {
   }, [api, current, activeWeek]);
 
   const fetchCurrWeek = async (newDate: string) => {
-    const newChannelId = Number(channelId);
-    const currWeekResult = await getWeeklyIncomplete({
-      channelId: newChannelId,
-      targetDate: newDate,
-    });
-    const weekdays = ['일', '월', '화', '수', '목', '금', '토'];
-    const newWeekDates = (weekData: IncompleteScoreResponse[]) => {
-      return weekData.map(data => {
-        const date = new Date(data.date);
-        const weekdayIndex = date.getDay();
-        const day = weekdays[weekdayIndex];
-
-        return {
-          ...data,
-          day,
-        };
+    try {
+      const newChannelId = Number(channelId);
+      const currWeekResult = await getWeeklyIncomplete({
+        channelId: newChannelId,
+        targetDate: newDate,
       });
-    };
+      const weekdays = ['일', '월', '화', '수', '목', '금', '토'];
+      const newWeekDates = (weekData: IncompleteScoreResponse[]) => {
+        return weekData.map(data => {
+          const date = new Date(data.date);
+          const weekdayIndex = date.getDay();
+          const day = weekdays[weekdayIndex];
 
-    setCurrWeek(newWeekDates(currWeekResult.result.incompleteScoreResponses));
+          return {
+            ...data,
+            day,
+          };
+        });
+      };
+
+      setCurrWeek(newWeekDates(currWeekResult.result.incompleteScoreResponses));
+    } catch (error) {
+      console.error('주간 미완료율 조회 실패:', error);
+    }
   };
 
   const handleActiveDate = async (date: string) => {

--- a/src/components/setting/groupSetting/InviteLink/InviteLink.tsx
+++ b/src/components/setting/groupSetting/InviteLink/InviteLink.tsx
@@ -17,8 +17,12 @@ const InviteLink: React.FC<InviteLinkProps> = ({ initialLink }) => {
   const channelId = Number(strChannelId);
 
   const handleGenerateLink = async () => {
-    const response = await postCreateInviteLink({ channelId: channelId });
-    setInviteLink(`${response.result.inviteLink}`);
+    try {
+      const response = await postCreateInviteLink({ channelId: channelId });
+      setInviteLink(`${response.result.inviteLink}`);
+    } catch (error) {
+      console.error('초대 링크 생성 실패:', error);
+    }
   };
 
   const handleCopyLink = () => {

--- a/src/hooks/useGroupSetting.ts
+++ b/src/hooks/useGroupSetting.ts
@@ -34,7 +34,7 @@ const useGroupSetting = () => {
         setCurrentUser(current || null);
         setIsLoading(false);
       } catch (error) {
-        console.error('멤버 조회 실패:', error);
+        console.error('그룹 사용자 조회 실패:', error);
         setIsLoading(false);
       }
     };
@@ -60,14 +60,18 @@ const useGroupSetting = () => {
   };
 
   const handleDone = async () => {
-    await putChangeGroupName({
-      channelId: channelId,
-      name: groupName,
-    });
-    setIsEdited(false);
-    toast({
-      title: '그룹 이름이 변경되었어요',
-    });
+    try {
+      await putChangeGroupName({
+        channelId: channelId,
+        name: groupName,
+      });
+      setIsEdited(false);
+      toast({
+        title: '그룹 이름이 변경되었어요',
+      });
+    } catch (error) {
+      console.error('그룹 이름 변경 실패:', error);
+    }
   };
 
   const handleSheet = (member: User) => {
@@ -86,23 +90,46 @@ const useGroupSetting = () => {
     setIsOpen(true);
   };
 
-  const handleExit = async (member: User) => {
-    try {
-      const isCurrentUserSelected = member.currentUser;
+  // const handleExit = async (member: User) => {
+  //   try {
+  //     const isCurrentUserSelected = member.currentUser;
 
-      if (isAdmin && !isCurrentUserSelected) {
+  //     if (isAdmin && !isCurrentUserSelected) {
+  //       await postBanUser({ channelId, email: member.email });
+  //       setMembers(prev => prev.filter(m => m.email !== member.email));
+  //       toast({ title: '탈퇴되었습니다' });
+  //     } else {
+  //       await deleteGroupUser({ channelId });
+  //       navigate('/group-select');
+  //     }
+
+  //     setIsOpen(false);
+  //   } catch (error) {
+  //     console.error('멤버 방출/그룹 나가기 실패:', error);
+  //   }
+  // };
+
+  const handleExit = async (member: User) => {
+    const isCurrentUserSelected = member.currentUser;
+
+    if (isAdmin && !isCurrentUserSelected) {
+      try {
         await postBanUser({ channelId, email: member.email });
         setMembers(prev => prev.filter(m => m.email !== member.email));
         toast({ title: '탈퇴되었습니다' });
-      } else {
+      } catch (error) {
+        console.error('멤버 방출 실패:', error);
+      }
+    } else {
+      try {
         await deleteGroupUser({ channelId });
         navigate('/group-select');
+      } catch (error) {
+        console.error('그룹 나가기 실패:', error);
       }
-
-      setIsOpen(false);
-    } catch (error) {
-      console.error('멤버 방출/그룹 나가기 실패:', error);
     }
+
+    setIsOpen(false);
   };
 
   const handleClose = () => {

--- a/src/hooks/useHouseworkStepTwo.ts
+++ b/src/hooks/useHouseworkStepTwo.ts
@@ -29,7 +29,7 @@ const useHouseworkStepTwo = () => {
         const response = await getGroupUser({ channelId });
         setMembers(response.result.userList);
       } catch (error) {
-        console.error('멤버 조회 실패:', error);
+        console.error('그룹 사용자 조회 실패:', error);
       } finally {
         setIsMemberLoading(false);
       }
@@ -50,28 +50,32 @@ const useHouseworkStepTwo = () => {
     const newTime = convertStartTime(startTime);
 
     if (houseworkId) {
-      if (userId) {
-        await putHousework({
-          channelId,
-          houseworkId: Number(houseworkId),
-          category,
-          startDate: formattedDate,
-          task,
-          startTime: newTime,
-          userId,
-        });
+      try {
+        if (userId) {
+          await putHousework({
+            channelId,
+            houseworkId: Number(houseworkId),
+            category,
+            startDate: formattedDate,
+            task,
+            startTime: newTime,
+            userId,
+          });
 
-        setTimeout(() => {
-          setActiveDate(formattedDate);
-          setActiveWeek(new Date(formattedDate));
-          setActiveTab('전체');
-          setWeekText(getWeekText(new Date(formattedDate)));
-          navigate(`/main/${channelId}`);
           setTimeout(() => {
-            reset();
-            setIsLoading(false);
-          }, 2000);
-        }, 2500);
+            setActiveDate(formattedDate);
+            setActiveWeek(new Date(formattedDate));
+            setActiveTab('전체');
+            setWeekText(getWeekText(new Date(formattedDate)));
+            navigate(`/main/${channelId}`);
+            setTimeout(() => {
+              reset();
+              setIsLoading(false);
+            }, 2000);
+          }, 2500);
+        }
+      } catch (error) {
+        console.error('집안일 수정 실패:', error);
       }
     } else {
       try {

--- a/src/hooks/usePresetSetting.ts
+++ b/src/hooks/usePresetSetting.ts
@@ -34,7 +34,7 @@ const usePresetSetting = () => {
       const categoryListData = response.result.categoryList;
       setCategoryList(categoryListData);
     } catch (error) {
-      console.error('카테고리 초기화 오류: ', error);
+      console.error('카테고리명 조회 실패: ', error);
     }
   };
 
@@ -68,7 +68,7 @@ const usePresetSetting = () => {
       await getPresetData();
       setCateActiveTab(Category.ALL);
     } catch (error) {
-      console.error('프리셋 아이템 추가 오류: ', error);
+      console.error('프리셋 아이템 추가 실패: ', error);
     }
   };
 
@@ -86,7 +86,7 @@ const usePresetSetting = () => {
       // 업데이트된 아이템 리스트 조회
       await getPresetData();
     } catch (error) {
-      console.error('프리셋 아이템 삭제 오류: ', error);
+      console.error('프리셋 아이템 삭제 실패: ', error);
     }
   };
 

--- a/src/hooks/useRegister.ts
+++ b/src/hooks/useRegister.ts
@@ -17,7 +17,7 @@ export const useRegister = () => {
         setName(response.result.nickName);
         setProfileUrl(response.result.profileImageUrl);
       } catch (error) {
-        console.error('사용자 정보 조회 실패:', error);
+        console.error('내 정보 조회 실패:', error);
       }
     };
 

--- a/src/hooks/useWeeklyStatistics.ts
+++ b/src/hooks/useWeeklyStatistics.ts
@@ -22,7 +22,7 @@ const useWeeklyStatistics = () => {
       const response = await getWeeklyTotalCount({ channelId, targetDate });
       setTotalCountData(response.result);
     } catch (error) {
-      console.error('주간 통계 데이터 조회 실패: ', error);
+      console.error('주간 통계 개수 데이터 조회 실패: ', error);
     }
   };
 

--- a/src/pages/group/GroupCreatePage.tsx
+++ b/src/pages/group/GroupCreatePage.tsx
@@ -22,11 +22,21 @@ const GroupCreatePage = () => {
 
   const handleNext = async () => {
     if (roomName.trim()) {
-      const createResult = await postCreateGroup({ name: roomName });
-      const createLink = await postCreateInviteLink({ channelId: createResult.result.channelId });
-      setInviteLink(createLink.result.inviteLink);
-      setChannelId(createResult.result.channelId);
-      setStep('invite');
+      try {
+        const createResult = await postCreateGroup({ name: roomName });
+        
+        try {
+          const createLink = await postCreateInviteLink({ channelId: createResult.result.channelId });
+          setInviteLink(createLink.result.inviteLink);
+          setChannelId(createResult.result.channelId);
+          setStep('invite');
+        } catch(error) {
+          console.error('초대 링크 생성 실패:',error);
+        }
+
+      } catch(error){
+        console.error('그룹 생성 실패:',error);
+      }
     }
   };
 

--- a/src/pages/group/GroupInviteReceivePage.tsx
+++ b/src/pages/group/GroupInviteReceivePage.tsx
@@ -21,6 +21,7 @@ const GroupInviteReceivePage = () => {
       navigate(`/main/${joinResult.result.channelId}`);
     } catch (error) {
       toast({ title: '코드를 다시 확인해주세요' });
+      console.error('그룹 입장 실패:',error);
     }
   };
 

--- a/src/pages/group/GroupSelectPage.tsx
+++ b/src/pages/group/GroupSelectPage.tsx
@@ -19,7 +19,7 @@ const GroupSelectPage = () => {
         const groups = await getMyGroup();
         setGroups(groups.result.channelList);
       } catch (error) {
-        console.error('그룹 조회 실패:', error);
+        console.error('그룹 목록 조회 실패:', error);
       } finally {
         setIsLoading(false); // 데이터 로드 완료
       }

--- a/src/services/axiosInstance.ts
+++ b/src/services/axiosInstance.ts
@@ -26,7 +26,16 @@ axiosInstance.interceptors.response.use(
     return response;
   },
   error => {
-    console.error('API 요청 실패:', error);
+    // 공통 에러 처리
+    if (error.response) {
+      console.error(
+        `API 요청 실패: HTTP ${error.response.status} (${error.response.data?.code}) - ${error.response.data?.message}`
+      );
+    } else if (error.request) {
+      console.error('API 요청 실패: 서버 응답이 없습니다.');
+    } else {
+      console.error('API 요청 실패:', error.message);
+    }
     return Promise.reject(error);
   }
 );

--- a/src/services/group/deleteGroupUser.ts
+++ b/src/services/group/deleteGroupUser.ts
@@ -2,13 +2,6 @@ import { axiosInstance } from '@/services/axiosInstance';
 import { LeaveGroupReq, LeaveGroupRes } from '@/types/apis/groupApi';
 
 export const deleteGroupUser = async ({ channelId }: LeaveGroupReq) => {
-  try {
-    const response = await axiosInstance.delete<LeaveGroupRes>(
-      `/api/v1/channels/${channelId}/leave`
-    );
-    return response.data;
-  } catch (error) {
-    console.error('방 나가기 실패:', error);
-    throw error;
-  }
+  const response = await axiosInstance.delete<LeaveGroupRes>(`/api/v1/channels/${channelId}/leave`);
+  return response.data;
 };

--- a/src/services/group/getGroupUser.ts
+++ b/src/services/group/getGroupUser.ts
@@ -6,13 +6,8 @@ export const getGroupUser = async (
   { channelId }: GetGroupUserReq,
   params: GetPageParams = { page: 0, size: 20 }
 ) => {
-  try {
-    const response = await axiosInstance.get<GetGroupUserRes>(
-      `/api/v1/channels/${channelId}/users`,
-      { params }
-    );
-    return response.data;
-  } catch (error) {
-    throw new Error('그룹 사용자 조회에 실패했습니다');
-  }
+  const response = await axiosInstance.get<GetGroupUserRes>(`/api/v1/channels/${channelId}/users`, {
+    params,
+  });
+  return response.data;
 };

--- a/src/services/group/getMyGroup.ts
+++ b/src/services/group/getMyGroup.ts
@@ -3,11 +3,6 @@ import { GetMyGroupRes } from '@/types/apis/groupApi';
 import { GetPageParams } from '@/types/apis/pageApi';
 
 export const getMyGroup = async (params: GetPageParams = { page: 0, size: 20 }) => {
-  try {
-    const response = await axiosInstance.get<GetMyGroupRes>(`/api/v1/channels/my`, { params });
-    return response.data;
-  } catch (error) {
-    console.error('방 목록 조회 실패:', error);
-    throw error;
-  }
+  const response = await axiosInstance.get<GetMyGroupRes>(`/api/v1/channels/my`, { params });
+  return response.data;
 };

--- a/src/services/group/postBanUser.ts
+++ b/src/services/group/postBanUser.ts
@@ -2,13 +2,8 @@ import { axiosInstance } from '@/services/axiosInstance';
 import { KickUserReq, KickUserRes } from '@/types/apis/groupApi';
 
 export const postBanUser = async ({ channelId, email }: KickUserReq) => {
-  try {
-    const response = await axiosInstance.post<KickUserRes>(`/api/v1/channels/${channelId}/kick`, {
-      email,
-    });
-    return response.data;
-  } catch (error) {
-    console.error('멤버 추방 실패:', error);
-    throw error;
-  }
+  const response = await axiosInstance.post<KickUserRes>(`/api/v1/channels/${channelId}/kick`, {
+    email,
+  });
+  return response.data;
 };

--- a/src/services/group/postCreateGroup.ts
+++ b/src/services/group/postCreateGroup.ts
@@ -2,10 +2,6 @@ import { axiosInstance } from '@/services/axiosInstance';
 import { CreateGroupReq, CreateGroupRes } from '@/types/apis/groupApi';
 
 export const postCreateGroup = async ({ name }: CreateGroupReq) => {
-  try {
-    const response = await axiosInstance.post<CreateGroupRes>('/api/v1/channels', { name });
-    return response.data;
-  } catch (error) {
-    throw new Error();
-  }
+  const response = await axiosInstance.post<CreateGroupRes>('/api/v1/channels', { name });
+  return response.data;
 };

--- a/src/services/group/postCreateInviteLink.ts
+++ b/src/services/group/postCreateInviteLink.ts
@@ -2,13 +2,8 @@ import { axiosInstance } from '@/services/axiosInstance';
 import { CreateInviteLinkReq, CreateInviteLinkRes } from '@/types/apis/groupApi';
 
 export const postCreateInviteLink = async ({ channelId }: CreateInviteLinkReq) => {
-  try {
-    const response = await axiosInstance.post<CreateInviteLinkRes>(
-      `/api/v1/channels/${channelId}/invite-link`
-    );
-    return response.data;
-  } catch (error) {
-    console.error('초대 링크 생성 실패:', error);
-    throw error;
-  }
+  const response = await axiosInstance.post<CreateInviteLinkRes>(
+    `/api/v1/channels/${channelId}/invite-link`
+  );
+  return response.data;
 };

--- a/src/services/group/postJoinGroup.ts
+++ b/src/services/group/postJoinGroup.ts
@@ -2,10 +2,6 @@ import { axiosInstance } from '@/services/axiosInstance';
 import { JoinGroupReq, JoinGroupRes } from '@/types/apis/groupApi';
 
 export const postJoinGroup = async ({ inviteLink }: JoinGroupReq) => {
-  try {
-    const response = await axiosInstance.post<JoinGroupRes>(`/api/v1/channels/join/${inviteLink}`);
-    return response.data;
-  } catch (error) {
-    throw new Error('유효한 링크인지 확인해주세요!');
-  }
+  const response = await axiosInstance.post<JoinGroupRes>(`/api/v1/channels/join/${inviteLink}`);
+  return response.data;
 };

--- a/src/services/group/putChangeGroupName.ts
+++ b/src/services/group/putChangeGroupName.ts
@@ -2,14 +2,9 @@ import { axiosInstance } from '@/services/axiosInstance';
 import { ChangeGroupNameReq, ChangeGroupNameRes } from '@/types/apis/groupApi';
 
 export const putChangeGroupName = async ({ channelId, name }: ChangeGroupNameReq) => {
-  try {
-    const response = await axiosInstance.put<ChangeGroupNameRes>(
-      `/api/v1/channels/${channelId}/name`,
-      { name }
-    );
-    return response.data;
-  } catch (error) {
-    console.error('방 이름 수정 실패:', error);
-    throw error;
-  }
+  const response = await axiosInstance.put<ChangeGroupNameRes>(
+    `/api/v1/channels/${channelId}/name`,
+    { name }
+  );
+  return response.data;
 };

--- a/src/services/housework/changeHouseworkStatus.ts
+++ b/src/services/housework/changeHouseworkStatus.ts
@@ -5,12 +5,8 @@ export const changeHouseworkStatus = async ({
   channelId,
   houseworkId,
 }: ChangeHouseworkStatusReq) => {
-  try {
-    const response = await axiosInstance.put<ChangeHouseworkStatusRes>(
-      `/api/v1/channels/${channelId}/houseworks/${houseworkId}/changeStatus`
-    );
-    return response.data;
-  } catch (error) {
-    throw new Error('집안일 상태 변경 실패');
-  }
+  const response = await axiosInstance.put<ChangeHouseworkStatusRes>(
+    `/api/v1/channels/${channelId}/houseworks/${houseworkId}/changeStatus`
+  );
+  return response.data;
 };

--- a/src/services/housework/deleteHouswork.ts
+++ b/src/services/housework/deleteHouswork.ts
@@ -2,12 +2,8 @@ import { axiosInstance } from '@/services/axiosInstance';
 import { DeleteHouseworkReq, DeleteHouseworkRes } from '@/types/apis/houseworkApi';
 
 export const deleteHousework = async ({ channelId, houseworkId }: DeleteHouseworkReq) => {
-  try {
-    const response = await axiosInstance.delete<DeleteHouseworkRes>(
-      `/api/v1/channels/${channelId}/houseworks/${houseworkId}`
-    );
-    return response.data;
-  } catch (error) {
-    throw new Error('집안일 삭제 실패');
-  }
+  const response = await axiosInstance.delete<DeleteHouseworkRes>(
+    `/api/v1/channels/${channelId}/houseworks/${houseworkId}`
+  );
+  return response.data;
 };

--- a/src/services/housework/getHouseworkById.ts
+++ b/src/services/housework/getHouseworkById.ts
@@ -1,13 +1,11 @@
 import { axiosInstance } from '@/services/axiosInstance';
 import { GetHouseworkByIdReq, GetHouseworkByIdRes } from '@/types/apis/houseworkApi';
 
+// 현재 호출부 없음
+// 집안일 id별 상세 정보 조회
 export const getHouseworkById = async ({ channelId, houseworkId }: GetHouseworkByIdReq) => {
-  try {
-    const response = await axiosInstance.get<GetHouseworkByIdRes>(
-      `/api/v1/channels/${channelId}/houseworks/${houseworkId}`
-    );
-    return response.data;
-  } catch (error) {
-    throw new Error('집안일 id별 상세 정보 조회 실패');
-  }
+  const response = await axiosInstance.get<GetHouseworkByIdRes>(
+    `/api/v1/channels/${channelId}/houseworks/${houseworkId}`
+  );
+  return response.data;
 };

--- a/src/services/housework/getHouseworks.ts
+++ b/src/services/housework/getHouseworks.ts
@@ -8,13 +8,9 @@ export const getHouseworks = async ({
   pageSize,
 }: GetHouseworkReq) => {
   const params = { targetDate, pageNumber, pageSize };
-  try {
-    const response = await axiosInstance.get<GetHouseworkRes>(
-      `/api/v1/channels/${channelId}/houseworks/${targetDate}/${pageNumber}/${pageSize}`,
-      { params }
-    );
-    return response.data;
-  } catch (error) {
-    throw new Error('집안일 목록 가져오기 실패');
-  }
+  const response = await axiosInstance.get<GetHouseworkRes>(
+    `/api/v1/channels/${channelId}/houseworks/${targetDate}/${pageNumber}/${pageSize}`,
+    { params }
+  );
+  return response.data;
 };

--- a/src/services/housework/getWeeklyIncomplete.ts
+++ b/src/services/housework/getWeeklyIncomplete.ts
@@ -2,17 +2,13 @@ import { axiosInstance } from '@/services/axiosInstance';
 import { GetWeeklyIncompleteReq, GetWeeklyIncompleteRes } from '@/types/apis/houseworkApi';
 
 export const getWeeklyIncomplete = async ({ channelId, targetDate }: GetWeeklyIncompleteReq) => {
-  try {
-    const response = await axiosInstance.get<GetWeeklyIncompleteRes>(
-      `/api/v1/channels/${channelId}/houseworks/daily/incomplete`,
-      {
-        params: {
-          targetDate,
-        },
-      }
-    );
-    return response.data;
-  } catch (error) {
-    throw new Error('주간 미완료율을 가져오는 데에 실패했습니다.');
-  }
+  const response = await axiosInstance.get<GetWeeklyIncompleteRes>(
+    `/api/v1/channels/${channelId}/houseworks/daily/incomplete`,
+    {
+      params: {
+        targetDate,
+      },
+    }
+  );
+  return response.data;
 };

--- a/src/services/housework/postHousework.ts
+++ b/src/services/housework/postHousework.ts
@@ -9,19 +9,15 @@ export const postHousework = async ({
   startTime,
   userId,
 }: AddHouseworkReq) => {
-  try {
-    const response = await axiosInstance.post<AddHouseworkRes>(
-      `api/v1/channels/${channelId}/houseworks`,
-      {
-        category,
-        task,
-        startDate,
-        startTime,
-        userId,
-      }
-    );
-    return response.data;
-  } catch (error) {
-    throw new Error('집안일 추가 실패');
-  }
+  const response = await axiosInstance.post<AddHouseworkRes>(
+    `api/v1/channels/${channelId}/houseworks`,
+    {
+      category,
+      task,
+      startDate,
+      startTime,
+      userId,
+    }
+  );
+  return response.data;
 };

--- a/src/services/housework/putHousework.ts
+++ b/src/services/housework/putHousework.ts
@@ -10,13 +10,9 @@ export const putHousework = async ({
   startTime,
   userId,
 }: PutHouseworkReq) => {
-  try {
-    const response = await axiosInstance.put<PutHouseworkRes>(
-      `api/v1/channels/${channelId}/houseworks/${houseworkId}`,
-      { category, task, startDate, startTime, userId }
-    );
-    return response.data;
-  } catch (error) {
-    throw new Error('집안일 수정 실패');
-  }
+  const response = await axiosInstance.put<PutHouseworkRes>(
+    `api/v1/channels/${channelId}/houseworks/${houseworkId}`,
+    { category, task, startDate, startTime, userId }
+  );
+  return response.data;
 };

--- a/src/services/noticeManage/postCompliment.ts
+++ b/src/services/noticeManage/postCompliment.ts
@@ -2,13 +2,9 @@ import { axiosInstance } from '@/services/axiosInstance';
 import { ComplimentReq, ComplimentRes } from '@/types/apis/noticeManage';
 
 export const postCompliment = async ({ channelId, targetUserId, reactDate }: ComplimentReq) => {
-  try {
-    const response = await axiosInstance.post<ComplimentRes>(
-      `/api/v1/channels/${channelId}/reactions/compliment`,
-      { targetUserId, reactDate }
-    );
-    return response.data;
-  } catch (error) {
-    throw new Error('칭찬하기에 실패했습니다.');
-  }
+  const response = await axiosInstance.post<ComplimentRes>(
+    `/api/v1/channels/${channelId}/reactions/compliment`,
+    { targetUserId, reactDate }
+  );
+  return response.data;
 };

--- a/src/services/noticeManage/postPoke.ts
+++ b/src/services/noticeManage/postPoke.ts
@@ -2,13 +2,9 @@ import { axiosInstance } from '@/services/axiosInstance';
 import { PokeReq, PokeRes } from '@/types/apis/noticeManage';
 
 export const postPoke = async ({ channelId, targetUserId, reactDate }: PokeReq) => {
-  try {
-    const response = await axiosInstance.post<PokeRes>(
-      `/api/v1/channels/${channelId}/reactions/poke`,
-      { targetUserId, reactDate }
-    );
-    return response.data;
-  } catch (error) {
-    throw new Error('찌르기에 실패했어요.');
-  }
+  const response = await axiosInstance.post<PokeRes>(
+    `/api/v1/channels/${channelId}/reactions/poke`,
+    { targetUserId, reactDate }
+  );
+  return response.data;
 };

--- a/src/services/onboarding/postPersonalKeyword.ts
+++ b/src/services/onboarding/postPersonalKeyword.ts
@@ -2,12 +2,8 @@ import { PostPersonalKeywordReq, PostPersonalKeywordRes } from './../../types/ap
 import { axiosInstance } from '@/services/axiosInstance';
 
 export const postPersonalKeyword = async ({ surveyResultText }: PostPersonalKeywordReq) => {
-  try {
-    const response = await axiosInstance.post<PostPersonalKeywordRes>(`api/v1/personalities`, {
-      surveyResultText,
-    });
-    return response.data;
-  } catch (error) {
-    throw new Error('성향 키워드 추출이 되지 않습니다.');
-  }
+  const response = await axiosInstance.post<PostPersonalKeywordRes>(`api/v1/personalities`, {
+    surveyResultText,
+  });
+  return response.data;
 };

--- a/src/services/preset/deleteCategory.ts
+++ b/src/services/preset/deleteCategory.ts
@@ -2,14 +2,10 @@ import { axiosInstance } from '@/services/axiosInstance';
 import { DeletePresetCategoryReq, DeletePresetCategoryRes } from '@/types/apis/presetApi';
 
 // 현재 호출부 없음
+// 프리셋 카테고리 삭제
 export const deleteCategory = async (data: DeletePresetCategoryReq) => {
-  try {
-    const response = await axiosInstance.delete<DeletePresetCategoryRes>(
-      `/api/v1/channels/${data.channelId}/presets/categories/${data.presetCategoryId}`
-    );
-    return response.data;
-  } catch (error) {
-    console.error('프리셋 카테고리 삭제 실패:', error);
-    throw error;
-  }
+  const response = await axiosInstance.delete<DeletePresetCategoryRes>(
+    `/api/v1/channels/${data.channelId}/presets/categories/${data.presetCategoryId}`
+  );
+  return response.data;
 };

--- a/src/services/preset/deletePresetItem.ts
+++ b/src/services/preset/deletePresetItem.ts
@@ -2,13 +2,8 @@ import { axiosInstance } from '@/services/axiosInstance';
 import { DeletePresetItemReq, DeletePresetItemRes } from '@/types/apis/presetApi';
 
 export const deletePresetItem = async (data: DeletePresetItemReq) => {
-  try {
-    const response = await axiosInstance.delete<DeletePresetItemRes>(
-      `/api/v1/channels/${data.channelId}/presets/categories/${data.presetCategoryId}/items/${data.presetItemId}`
-    );
-    return response.data;
-  } catch (error) {
-    console.error('프리셋 아이템 삭제 실패:', error);
-    throw error;
-  }
+  const response = await axiosInstance.delete<DeletePresetItemRes>(
+    `/api/v1/channels/${data.channelId}/presets/categories/${data.presetCategoryId}/items/${data.presetItemId}`
+  );
+  return response.data;
 };

--- a/src/services/preset/getAllCategoryKeywordList.ts
+++ b/src/services/preset/getAllCategoryKeywordList.ts
@@ -3,18 +3,14 @@ import { GetAllPresetKeywordListReq, GetAllPresetKeywordListRes } from '@/types/
 import { GetPageParams } from '@/types/apis/pageApi';
 
 // 현재 호출부 없음
+// 프리셋 전체 키워드 리스트 조회
 export const getAllCategoryKeywordList = async (
   data: GetAllPresetKeywordListReq,
   params: GetPageParams = { page: 0, size: 20 }
 ) => {
-  try {
-    const response = await axiosInstance.get<GetAllPresetKeywordListRes>(
-      `/api/v1/channels/${data.channelId}/presets/keywords`,
-      { params }
-    );
-    return response.data;
-  } catch (error) {
-    console.error('프리셋 전체 키워드 리스트 조회 실패:', error);
-    throw error;
-  }
+  const response = await axiosInstance.get<GetAllPresetKeywordListRes>(
+    `/api/v1/channels/${data.channelId}/presets/keywords`,
+    { params }
+  );
+  return response.data;
 };

--- a/src/services/preset/getAllCategoryList.ts
+++ b/src/services/preset/getAllCategoryList.ts
@@ -6,14 +6,9 @@ export const getAllCategoryList = async (
   data: GetAllPresetListReq,
   params: GetPageParams = { page: 0, size: 20 }
 ) => {
-  try {
-    const response = await axiosInstance.get<GetAllPresetListRes>(
-      `/api/v1/channels/${data.channelId}/presets/categories/items`,
-      { params }
-    );
-    return response.data;
-  } catch (error) {
-    console.error('프리셋 전체 리스트 조회 실패:', error);
-    throw error;
-  }
+  const response = await axiosInstance.get<GetAllPresetListRes>(
+    `/api/v1/channels/${data.channelId}/presets/categories/items`,
+    { params }
+  );
+  return response.data;
 };

--- a/src/services/preset/getAllCategoryName.ts
+++ b/src/services/preset/getAllCategoryName.ts
@@ -6,14 +6,9 @@ export const getAllCategoryName = async (
   { channelId }: GetAllPresetCategoryReq,
   params: GetPageParams = { page: 0, size: 20 }
 ) => {
-  try {
-    const response = await axiosInstance.get<GetAllPresetCategoryRes>(
-      `/api/v1/channels/${channelId}/presets/categories/names`,
-      { params }
-    );
-    return response.data;
-  } catch (error) {
-    console.error('프리셋 전체 카테고리 이름 조회 실패:', error);
-    throw error;
-  }
+  const response = await axiosInstance.get<GetAllPresetCategoryRes>(
+    `/api/v1/channels/${channelId}/presets/categories/names`,
+    { params }
+  );
+  return response.data;
 };

--- a/src/services/preset/getSingleCategoryList.ts
+++ b/src/services/preset/getSingleCategoryList.ts
@@ -2,18 +2,15 @@ import { axiosInstance } from '@/services/axiosInstance';
 import { GetSinglePresetListReq, GetSinglePresetListRes } from '@/types/apis/presetApi';
 import { GetPageParams } from '@/types/apis/pageApi';
 
+// 현재 호출부 없음
+// 프리셋 특정 카테고리 조회
 export const getSingleCategoryList = async (
   data: GetSinglePresetListReq,
   params: GetPageParams = { page: 0, size: 20 }
 ) => {
-  try {
-    const response = await axiosInstance.get<GetSinglePresetListRes>(
-      `/api/v1/channels/${data.channelId}/presets/categories/${data.presetCategoryId}/items`,
-      { params }
-    );
-    return response.data;
-  } catch (error) {
-    console.error('프리셋 특정 카테고리 조회 실패:', error);
-    throw error;
-  }
+  const response = await axiosInstance.get<GetSinglePresetListRes>(
+    `/api/v1/channels/${data.channelId}/presets/categories/${data.presetCategoryId}/items`,
+    { params }
+  );
+  return response.data;
 };

--- a/src/services/preset/postCreateCategory.ts
+++ b/src/services/preset/postCreateCategory.ts
@@ -2,15 +2,11 @@ import { axiosInstance } from '@/services/axiosInstance';
 import { CreatePresetCategoryReq, CreatePresetCategoryRes } from '@/types/apis/presetApi';
 
 // 현재 호출부 없음
+// 프리셋 카테고리 생성
 export const postCreateCategory = async ({ channelId, category }: CreatePresetCategoryReq) => {
-  try {
-    const response = await axiosInstance.post<CreatePresetCategoryRes>(
-      `/api/v1/channels/${channelId}/presets/categories`,
-      { category }
-    );
-    return response.data;
-  } catch (error) {
-    console.error('프리셋 카테고리 생성 실패:', error);
-    throw error;
-  }
+  const response = await axiosInstance.post<CreatePresetCategoryRes>(
+    `/api/v1/channels/${channelId}/presets/categories`,
+    { category }
+  );
+  return response.data;
 };

--- a/src/services/preset/postCreatePresetItem.ts
+++ b/src/services/preset/postCreatePresetItem.ts
@@ -6,14 +6,9 @@ export const postCreatePresetItem = async ({
   presetCategoryId,
   name,
 }: CreatePresetItemReq) => {
-  try {
-    const response = await axiosInstance.post<CreatePresetItemRes>(
-      `/api/v1/channels/${channelId}/presets/categories/${presetCategoryId}/items`,
-      { name }
-    );
-    return response.data;
-  } catch (error) {
-    console.error('프리셋 아이템 생성 실패:', error);
-    throw error;
-  }
+  const response = await axiosInstance.post<CreatePresetItemRes>(
+    `/api/v1/channels/${channelId}/presets/categories/${presetCategoryId}/items`,
+    { name }
+  );
+  return response.data;
 };

--- a/src/services/statistics/getMonthlyMVP.ts
+++ b/src/services/statistics/getMonthlyMVP.ts
@@ -2,18 +2,13 @@ import { axiosInstance } from '@/services/axiosInstance';
 import { GetMonthlyMVPReq, GetMonthlyMVPRes } from '@/types/apis/statisticsApi';
 
 export const getMonthlyMVP = async (data: GetMonthlyMVPReq) => {
-  try {
-    const response = await axiosInstance.get<GetMonthlyMVPRes>(
-      `/api/v1/channels/${data.channelId}/statistics/monthly/mvp`,
-      {
-        params: {
-          targetMonth: data.targetMonth,
-        },
-      }
-    );
-    return response.data;
-  } catch (error) {
-    console.error('월간 통계 MVP 조회 실패: ', error);
-    throw error;
-  }
+  const response = await axiosInstance.get<GetMonthlyMVPRes>(
+    `/api/v1/channels/${data.channelId}/statistics/monthly/mvp`,
+    {
+      params: {
+        targetMonth: data.targetMonth,
+      },
+    }
+  );
+  return response.data;
 };

--- a/src/services/statistics/getMonthlyScore.ts
+++ b/src/services/statistics/getMonthlyScore.ts
@@ -2,18 +2,13 @@ import { axiosInstance } from '@/services/axiosInstance';
 import { GetMonthlyScoreReq, GetMonthlyScoreRes } from '@/types/apis/statisticsApi';
 
 export const getMonthlyScore = async (data: GetMonthlyScoreReq) => {
-  try {
-    const response = await axiosInstance.get<GetMonthlyScoreRes>(
-      `/api/v1/channels/${data.channelId}/statistics/monthly/score`,
-      {
-        params: {
-          targetMonth: data.targetMonth,
-        },
-      }
-    );
-    return response.data;
-  } catch (error) {
-    console.error('월간 통계 캘린더 조회 실패: ', error);
-    throw error;
-  }
+  const response = await axiosInstance.get<GetMonthlyScoreRes>(
+    `/api/v1/channels/${data.channelId}/statistics/monthly/score`,
+    {
+      params: {
+        targetMonth: data.targetMonth,
+      },
+    }
+  );
+  return response.data;
 };

--- a/src/services/statistics/getWeeklyScore.ts
+++ b/src/services/statistics/getWeeklyScore.ts
@@ -2,14 +2,9 @@ import { axiosInstance } from '@/services/axiosInstance';
 import { GetWeeklyScoreReq, GetWeeklyScoreRes } from '@/types/apis/statisticsApi';
 
 export const getWeeklyScore = async ({ channelId, targetDate }: GetWeeklyScoreReq) => {
-  try {
-    const response = await axiosInstance.get<GetWeeklyScoreRes>(
-      `/api/v1/channels/${channelId}/statistics/weekly/score`,
-      { params: { targetDate } }
-    );
-    return response.data;
-  } catch (error) {
-    console.error('주간 통계 랭킹 조회 실패: ', error);
-    throw error;
-  }
+  const response = await axiosInstance.get<GetWeeklyScoreRes>(
+    `/api/v1/channels/${channelId}/statistics/weekly/score`,
+    { params: { targetDate } }
+  );
+  return response.data;
 };

--- a/src/services/statistics/getWeeklyTotalCount.ts
+++ b/src/services/statistics/getWeeklyTotalCount.ts
@@ -2,14 +2,9 @@ import { axiosInstance } from '@/services/axiosInstance';
 import { GetWeeklyTotalCountReq, GetWeeklyTotalCountRes } from '@/types/apis/statisticsApi';
 
 export const getWeeklyTotalCount = async ({ channelId, targetDate }: GetWeeklyTotalCountReq) => {
-  try {
-    const response = await axiosInstance.get<GetWeeklyTotalCountRes>(
-      `/api/v1/channels/${channelId}/statistics/weekly/totalCount`,
-      { params: { targetDate } }
-    );
-    return response.data;
-  } catch (error) {
-    console.error('주간 통계 개수 조회 실패: ', error);
-    throw error;
-  }
+  const response = await axiosInstance.get<GetWeeklyTotalCountRes>(
+    `/api/v1/channels/${channelId}/statistics/weekly/totalCount`,
+    { params: { targetDate } }
+  );
+  return response.data;
 };

--- a/src/services/user/deleteUser.ts
+++ b/src/services/user/deleteUser.ts
@@ -2,11 +2,6 @@ import { axiosInstance } from '@/services/axiosInstance';
 import { DeleteMyInfoRes } from '@/types/apis/userApi';
 
 export const deleteUser = async () => {
-  try {
-    const response = await axiosInstance.delete<DeleteMyInfoRes>(`/api/v1/users/my`);
-    return response.data;
-  } catch (error) {
-    console.error('회원 탈퇴 실패:', error);
-    throw error;
-  }
+  const response = await axiosInstance.delete<DeleteMyInfoRes>(`/api/v1/users/my`);
+  return response.data;
 };

--- a/src/services/user/getMyInfo.ts
+++ b/src/services/user/getMyInfo.ts
@@ -2,10 +2,6 @@ import { axiosInstance } from '@/services/axiosInstance';
 import { GetMyInfoRes } from '@/types/apis/userApi';
 
 export const getMyInfo = async () => {
-  try {
-    const response = await axiosInstance.get<GetMyInfoRes>(`/api/v1/users/my`);
-    return response.data;
-  } catch (error) {
-    throw new Error('내 정보 조회에 실패했습니다');
-  }
+  const response = await axiosInstance.get<GetMyInfoRes>(`/api/v1/users/my`);
+  return response.data;
 };

--- a/src/services/user/getMyInitState.ts
+++ b/src/services/user/getMyInitState.ts
@@ -2,10 +2,6 @@ import { axiosInstance } from '@/services/axiosInstance';
 import { GetMyInitStateRes } from '@/types/apis/userApi';
 
 export const getMyInitState = async () => {
-  try {
-    const response = await axiosInstance.get<GetMyInitStateRes>(`/api/v1/users/my/profile/setup`);
-    return response.data;
-  } catch (error) {
-    throw new Error('내 초기 설정 상태 조회에 실패했습니다');
-  }
+  const response = await axiosInstance.get<GetMyInitStateRes>(`/api/v1/users/my/profile/setup`);
+  return response.data;
 };

--- a/src/services/user/getSpecificUser.ts
+++ b/src/services/user/getSpecificUser.ts
@@ -1,11 +1,9 @@
 import { axiosInstance } from '@/services/axiosInstance';
 import { GetSpecificUserReq, GetSpecificUserRes } from '@/types/apis/userApi';
 
+// 현재 호출부 없음
+// 특정 유저 정보 조회
 export const getSpecificUser = async ({ userId }: GetSpecificUserReq) => {
-  try {
-    const response = await axiosInstance.get<GetSpecificUserRes>(`/api/v1/users/${userId}`);
-    return response.data;
-  } catch (error) {
-    throw new Error('특정 유저 정보 조회에 실패했습니다');
-  }
+  const response = await axiosInstance.get<GetSpecificUserRes>(`/api/v1/users/${userId}`);
+  return response.data;
 };

--- a/src/services/user/patchMyInfo.ts
+++ b/src/services/user/patchMyInfo.ts
@@ -2,12 +2,8 @@ import { axiosInstance } from '@/services/axiosInstance';
 import { PatchMyProfileReq, PatchMyProfileRes } from '@/types/apis/userApi';
 
 export const patchMyInfo = async ({ nickName }: PatchMyProfileReq) => {
-  try {
-    const response = await axiosInstance.patch<PatchMyProfileRes>(`/api/v1/users/my/profile`, {
-      nickName,
-    });
-    return response.data;
-  } catch (error) {
-    throw new Error('프로필 수정에 실패했습니다');
-  }
+  const response = await axiosInstance.patch<PatchMyProfileRes>(`/api/v1/users/my/profile`, {
+    nickName,
+  });
+  return response.data;
 };

--- a/src/services/user/patchMyInitState.ts
+++ b/src/services/user/patchMyInitState.ts
@@ -2,12 +2,6 @@ import { axiosInstance } from '@/services/axiosInstance';
 import { PatchMyInitStateRes } from '@/types/apis/userApi';
 
 export const patchMyInitState = async () => {
-  try {
-    const response = await axiosInstance.patch<PatchMyInitStateRes>(
-      `/api/v1/users/my/profile/setup`
-    );
-    return response.data;
-  } catch (error) {
-    throw new Error('내 초기 상태 변경에 실패했습니다');
-  }
+  const response = await axiosInstance.patch<PatchMyInitStateRes>(`/api/v1/users/my/profile/setup`);
+  return response.data;
 };


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

- 공통 에러처리 및 관련 로직 리팩토링

## 📌 이슈 넘버

- #16 

## 📝 작업 내용

- axios 인터셉터 공통 에러 처리 추가
- 서비스 단의 try-catch 제거 및 호출부로 에러처리 통일
- 동일한 에러 정보가 호출 위치마다 중복 출력되던 문제를 개선
- 동일 API 호출에서 다르게 표시되던 에러 로그 메세지를 통일
- 에러 메세지 '방' → '그룹'으로 네이밍 통일

## 📸 스크린샷(선택)

- 개선 전
  - 동일한 에러가 호출 위치마다 중복으로 출력되어 불필요한 로그가 발생
  - 직관적으로 원인을 파악하기 어려운 상태

![캡처2](https://github.com/user-attachments/assets/f3aeedb5-fb66-40d3-b237-d3e9995ca400)

- 개선 후
  - 서버 응답 여부에 따라 에러를 분기 처리하고, 중복된 로그 제거
  - 서버로부터 전달받은 코드와 메시지를 로그에 출력하여 에러 원인을 명확히 파악할 수 있도록 개선

![캡처3](https://github.com/user-attachments/assets/2ed6d28d-1855-4f98-81a8-8c7930405fcb)

![캡처](https://github.com/user-attachments/assets/f0687ff5-e69e-408e-9559-5a66305b95fa)

![캡처1](https://github.com/user-attachments/assets/1939b012-edc8-4a68-835c-ae4ebcc736aa)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
