### PR TITLE
Feature/#50 - 그룹 초대 페이지 로직 분리

### DIFF
--- a/src/hooks/useGroupInvite.ts
+++ b/src/hooks/useGroupInvite.ts
@@ -1,0 +1,31 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { postJoinGroup } from '@/services/group/postJoinGroup';
+import { useToast } from '@/hooks/use-toast';
+
+export const useGroupInvite = () => {
+  const [inviteLink, setInviteLink] = useState('');
+  const navigate = useNavigate();
+  const { toast } = useToast();
+
+  const handleBack = () => {
+    navigate('/group-select');
+  };
+
+  const handleGoIn = async () => {
+    try {
+      const joinResult = await postJoinGroup({ inviteLink });
+      navigate(`/main/${joinResult.result.channelId}`);
+    } catch (error) {
+      toast({ title: '코드를 다시 확인해주세요' });
+      console.error('그룹 입장 실패:', error);
+    }
+  };
+
+  return {
+    inviteLink,
+    setInviteLink,
+    handleBack,
+    handleGoIn,
+  };
+};

--- a/src/pages/group/GroupInviteReceivePage.tsx
+++ b/src/pages/group/GroupInviteReceivePage.tsx
@@ -1,30 +1,11 @@
 import Button from '@/components/common/button/Button/Button';
 import Header from '@/components/common/header/Header';
 import InputBox from '@/components/common/input/InputBox';
-import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
-import { postJoinGroup } from '@/services/group/postJoinGroup';
-import { useToast } from '@/hooks/use-toast';
 import MetaTags from '@/components/common/metaTags/MetaTags';
+import { useGroupInvite } from '@/hooks/useGroupInvite';
 
 const GroupInviteReceivePage = () => {
-  const [inviteLink, setInviteLink] = useState('');
-  const navigate = useNavigate();
-  const { toast } = useToast();
-
-  const handleBack = () => {
-    navigate('/group-select');
-  };
-
-  const handleGoIn = async () => {
-    try {
-      const joinResult = await postJoinGroup({ inviteLink });
-      navigate(`/main/${joinResult.result.channelId}`);
-    } catch (error) {
-      toast({ title: '코드를 다시 확인해주세요' });
-      console.error('그룹 입장 실패:', error);
-    }
-  };
+  const { inviteLink, setInviteLink, handleBack, handleGoIn } = useGroupInvite();
 
   return (
     <div className={`flex h-screen flex-col`}>


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

> 그룹 초대 페이지 로직 분리

## 📌 이슈 넘버

- #3 
- #5 
- #50 

## 📝 작업 내용
- useGroupInvite 파일 추가

## 📸 스크린샷(선택)

## 💬리뷰 요구사항(선택)

> **초대는 2명이상이 있어야 하므로 테스트하지 못했습니다. 테스트할 때 말씀해주시면 감사하겠습니다.**
