### PR TITLE
Feature/#61 - 집안일 추가 라우팅 수정

### DIFF
--- a/src/components/common/bottomNav/BottomNav.tsx
+++ b/src/components/common/bottomNav/BottomNav.tsx
@@ -68,7 +68,7 @@ const BottomNav: React.FC = () => {
         </div>
       ))}
       <div className='flex flex-1 justify-center'>
-        <AddHouseWorkBtn handleClick={handleClick(`/add-housework/${channelId}/step1`)} />
+        <AddHouseWorkBtn handleClick={handleClick(`/add-housework/${channelId}`)} />
       </div>
       {navItems.slice(2).map(item => (
         <div key={item.name} className='flex flex-1 justify-center'>

--- a/src/hooks/useHomePage.ts
+++ b/src/hooks/useHomePage.ts
@@ -177,7 +177,7 @@ export const useHomePage = () => {
       if (targetHousework?.status === HOUSEWORK_STATUS.COMPLETE) {
         toast({ title: '완료한 집안일은 수정할 수 없어요' });
       } else {
-        navigate(`/add-housework/edit/${channelId}/${houseworkId}/step1`, {
+        navigate(`/add-housework/edit/${channelId}/${houseworkId}`, {
           state: targetHousework,
         });
       }


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

> 바텀 네비게이션
> 메인페이지 집안일 리스트
- 집안일 추가, 수정 라우팅 수정

## 📌 이슈 넘버

- #61 

## 📝 작업 내용
- 위와 동일

## 📸 스크린샷(선택)

## 💬리뷰 요구사항(선택)

> 수정 할 사항 있으면 말씀해주세요.
