### PR TITLE
Feature/#45 - 그룹 설정 페이지 성능 최적화

### DIFF
--- a/src/components/setting/groupSetting/MemberItems/MemberItems.tsx
+++ b/src/components/setting/groupSetting/MemberItems/MemberItems.tsx
@@ -28,4 +28,4 @@ const MemberItems: React.FC<MemberItemsProps> = ({ leader, members, currentUser,
   );
 };
 
-export default MemberItems;
+export default React.memo(MemberItems);

--- a/src/hooks/useGroupSetting.ts
+++ b/src/hooks/useGroupSetting.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { User } from '@/types/apis/groupApi';
 import { getGroupUser } from '@/services/group/getGroupUser';
@@ -24,23 +24,23 @@ const useGroupSetting = () => {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<boolean>(false);
 
-  useEffect(() => {
-    const fetchGroupMembers = async () => {
-      try {
-        const response = await getGroupUser({ channelId });
-        setGroupName(response.result.name);
-        setMembers(response.result.userList);
-        const current = response.result.userList.find(user => user.currentUser);
-        setCurrentUser(current || null);
-        setIsLoading(false);
-      } catch (error) {
-        console.error('그룹 사용자 조회 실패:', error);
-        setIsLoading(false);
-      }
-    };
+  const fetchGroupMembers = useCallback(async () => {
+    try {
+      const response = await getGroupUser({ channelId });
+      setGroupName(response.result.name);
+      setMembers(response.result.userList);
+      const current = response.result.userList.find(user => user.currentUser);
+      setCurrentUser(current || null);
+    } catch (error) {
+      console.error('그룹 사용자 조회 실패:', error);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [channelId]);
 
+  useEffect(() => {
     fetchGroupMembers();
-  }, []);
+  }, [fetchGroupMembers]);
 
   const handleMovePreset = () => {
     navigate(`/group-setting/${channelId}/preset-setting`);

--- a/src/pages/group/GroupSettingPage.tsx
+++ b/src/pages/group/GroupSettingPage.tsx
@@ -1,6 +1,6 @@
+import React, { Suspense } from 'react';
 import SettingHeaderContainer from '@/components/common/header/Header';
 import InputWithLabel from '@/components/common/input/InputWithLabel';
-import MemberItems from '@/components/setting/groupSetting/MemberItems/MemberItems';
 import InviteLinkWithLabel from '@/components/setting/groupSetting/InviteLink/InviteLinkWithLabel';
 import ExitSheet from '@/components/setting/ExitSheet/ExitSheet';
 import { INPUT_VALIDATION } from '@/constants/validation';
@@ -9,6 +9,10 @@ import PresetSettingBtn from '@/components/setting/groupSetting/PresetSettingBtn
 import ErrorMessage from '@/components/common/errorMessage/ErrorMessage';
 import MetaTags from '@/components/common/metaTags/MetaTags';
 import { useParams } from 'react-router-dom';
+
+const MemberItems = React.lazy(
+  () => import('@/components/setting/groupSetting/MemberItems/MemberItems')
+);
 
 const GroupSettingPage = () => {
   const {
@@ -61,12 +65,16 @@ const GroupSettingPage = () => {
           />
           {error && <ErrorMessage message={INPUT_VALIDATION.roomName.errorMessage} />}
         </div>
-        <MemberItems
-          leader={isAdmin}
-          members={members}
-          currentUser={currentUser}
-          handleClick={handleSheet}
-        />
+
+        <Suspense fallback={<div></div>}>
+          <MemberItems
+            leader={isAdmin}
+            members={members}
+            currentUser={currentUser}
+            handleClick={handleSheet}
+          />
+        </Suspense>
+
         <InviteLinkWithLabel />
         <PresetSettingBtn handleClick={handleMovePreset} />
       </div>


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

> 그룹 설정 페이지 - 성능 최적화

## 📌 이슈 넘버

- #17 
- #22 
- #45 

## 📝 작업 내용
- 훅 내부의 fetchGroupMembers 함수 메모이제이션
- selctedMember, isEdited 상태 관리 제거 후 Ref로 변경된 값만 관리
- MemberItems 컴포넌트 지연 로딩

## 📸 스크린샷(선택)

## 💬리뷰 요구사항(선택)

> 수정 할 사항 있으면 말씀해주세요
