### PR TITLE
Feature/#66 - 주간 통계 페이지 성능 최적화 & 리팩토링

### DIFF
--- a/src/components/statistics/weekly/WeeklyStatDate/WeeklyStatDate.tsx
+++ b/src/components/statistics/weekly/WeeklyStatDate/WeeklyStatDate.tsx
@@ -1,5 +1,5 @@
 import { ArrowLeftIcon, ArrowRightIcon } from '@/components/common/icon';
-import React from 'react';
+import { memo } from 'react';
 import { getWeekText } from '@/utils/dateUtils';
 
 export interface WeeklyStatDateProps {
@@ -11,20 +11,13 @@ export interface WeeklyStatDateProps {
   handleNextWeek: () => void;
 }
 
-const WeeklyStatDate: React.FC<WeeklyStatDateProps> = ({
-  currentDate,
-  handlePrevWeek,
-  handleNextWeek,
-}) => {
+const WeeklyStatDate = ({ currentDate, handlePrevWeek, handleNextWeek }: WeeklyStatDateProps) => {
+
   // 다음 주로 이동 금지 조건 (오늘 날짜 기준으로 바로 비활성화)
   const isNextWeekDisabled = () => {
     const today = new Date();
-    today.setHours(0, 0, 0, 0); // 오늘 날짜의 시간 초기화 (날짜 비교만)
-
-    const nextWeekStart = new Date(today);
-    nextWeekStart.setDate(today.getDate() + 7); // 오늘 기준 다음 주의 시작
-
-    return currentDate >= today; // 오늘 이후 날짜로 넘어갈 수 없도록
+    today.setHours(0, 0, 0, 0);
+    return currentDate >= today;
   };
 
   return (
@@ -34,10 +27,10 @@ const WeeklyStatDate: React.FC<WeeklyStatDateProps> = ({
       </button>
       <span className='w-44 text-center text-gray2 font-subhead'>{getWeekText(currentDate)}</span>
       <button onClick={handleNextWeek} disabled={isNextWeekDisabled()}>
-        <ArrowRightIcon className={`text-gray2 ${isNextWeekDisabled() ? 'opacity-30' : ''}`} />
+        <ArrowRightIcon className={`text-gray2 ${isNextWeekDisabled() && 'opacity-30'}`} />
       </button>
     </div>
   );
 };
 
-export default WeeklyStatDate;
+export default memo(WeeklyStatDate);

--- a/src/hooks/useWeeklyStatistics.ts
+++ b/src/hooks/useWeeklyStatistics.ts
@@ -2,7 +2,7 @@ import { getWeeklyScore } from '@/services/statistics/getWeeklyScore';
 import { getWeeklyTotalCount } from '@/services/statistics/getWeeklyTotalCount';
 import useWeeklyStateStore from '@/store/useWeeklyStatisticsStore';
 import { getFormattedDate } from '@/utils/dateUtils';
-import { useEffect } from 'react';
+import { useCallback, useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 
 const useWeeklyStatistics = () => {
@@ -12,13 +12,25 @@ const useWeeklyStatistics = () => {
     useWeeklyStateStore();
 
   useEffect(() => {
-    getTotalCountData();
-    getScoreCountData();
+    setCurrentDate(prevDate => {
+      if (prevDate.toDateString() !== new Date().toDateString()) {
+        return new Date();
+      }
+      return prevDate;
+    });
+  }, []);
+
+  useEffect(() => {
+    const fetchCountData = async () => {
+      const targetDate = getFormattedDate(currentDate);
+      await Promise.allSettled([getTotalCountData(targetDate), getScoreCountData(targetDate)]);
+    };
+
+    fetchCountData();
   }, [currentDate]);
 
-  const getTotalCountData = async () => {
+  const getTotalCountData = async (targetDate: string) => {
     try {
-      const targetDate = getFormattedDate(currentDate);
       const response = await getWeeklyTotalCount({ channelId, targetDate });
       setTotalCountData(response.result);
     } catch (error) {
@@ -26,9 +38,8 @@ const useWeeklyStatistics = () => {
     }
   };
 
-  const getScoreCountData = async () => {
+  const getScoreCountData = async (targetDate: string) => {
     try {
-      const targetDate = getFormattedDate(currentDate);
       const response = await getWeeklyScore({ channelId, targetDate });
       setScoreCountData(response.result.completeScoreSortedResponse);
     } catch (error) {
@@ -36,21 +47,21 @@ const useWeeklyStatistics = () => {
     }
   };
 
-  const handlePrevWeek = () => {
+  const handlePrevWeek = useCallback(() => {
     setCurrentDate((prevDate: Date) => {
       const newDate = new Date(prevDate);
       newDate.setDate(newDate.getDate() - 7);
       return newDate;
     });
-  };
+  }, [setCurrentDate]);
 
-  const handleNextWeek = () => {
+  const handleNextWeek = useCallback(() => {
     setCurrentDate(prevDate => {
       const newDate = new Date(prevDate);
       newDate.setDate(newDate.getDate() + 7);
       return newDate;
     });
-  };
+  }, [setCurrentDate]);
 
   return {
     handlePrevWeek,

--- a/src/pages/statistics/WeeklyStatisticsPage.tsx
+++ b/src/pages/statistics/WeeklyStatisticsPage.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
   WeeklyCompletion,
   WeeklyRanking,
@@ -10,7 +9,7 @@ import useWeeklyStatistics from '@/hooks/useWeeklyStatistics';
 import MetaTags from '@/components/common/metaTags/MetaTags';
 import { useParams } from 'react-router-dom';
 
-const WeeklyStatisticsPage: React.FC = () => {
+const WeeklyStatisticsPage = () => {
   const { currentDate, totalCountData, scoreCountData } = useWeeklyStateStore();
   const { handlePrevWeek, handleNextWeek } = useWeeklyStatistics();
   const { channelId } = useParams();


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

- 주간 통계 페이지 성능 최적화 & 리팩토링

## 📌 이슈 넘버

- #66 

## 📝 작업 내용
- React.memo, useCallback 사용하여 최적화
- 리팩토링
  - 현재날짜 상태값 초기화 처리
  - API 호출 병렬처리로 변경
  - 미사용 로직 제거

## 📸 스크린샷(선택)
- **페이지 진입 시 WeeklyStatDate 컴포넌트 리렌더링 횟수 감소 (6회 → 1회)**
![image](https://github.com/user-attachments/assets/3cd481fc-39c8-4ab3-9027-4c066717b85d)
- **날짜 변경 시 WeeklyStatDate 컴포넌트 리렌더링 횟수 감소 (3회 → 1회)**
![image](https://github.com/user-attachments/assets/b88a4d2a-2726-4b5b-97f2-7672b57bdff1)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
