### PR TITLE
Feature/#23 - imporve add housework

### DIFF
--- a/src/components/common/bottomSheet/BottomSheet.tsx
+++ b/src/components/common/bottomSheet/BottomSheet.tsx
@@ -1,5 +1,5 @@
 import { Sheet } from 'react-modal-sheet';
-import React from 'react';
+import React, { useCallback, useMemo } from 'react';
 import BottomSheetTitle from '@/components/common/bottomSheet/BottomSheetTitle/BottomSheetTitle';
 import CloseBtn from '@/components/common/bottomSheet/CloseBtn/CloseBtn';
 
@@ -23,6 +23,21 @@ const BottomSheet: React.FC<BottomSheetProps> = ({
   closeBtn = true,
   children,
 }) => {
+  const handleClick = useCallback(() => {
+    setOpen(false);
+  }, []);
+
+  const memoizedTitle = useMemo(() => title, [title]);
+
+  const SheetHeader = useMemo(
+    () => (
+      <Sheet.Header>
+        <BottomSheetTitle title={memoizedTitle} />
+      </Sheet.Header>
+    ),
+    [memoizedTitle]
+  );
+
   return (
     <>
       <Sheet
@@ -33,10 +48,8 @@ const BottomSheet: React.FC<BottomSheetProps> = ({
       >
         <div className='relative mx-auto h-full w-full max-w'>
           <Sheet.Container>
-            {closeBtn && <CloseBtn handleClick={() => setOpen(false)} />}
-            <Sheet.Header>
-              <BottomSheetTitle title={title} />
-            </Sheet.Header>
+            {closeBtn && <CloseBtn handleClick={handleClick} />}
+            {SheetHeader}
             <Sheet.Content>{children}</Sheet.Content>
           </Sheet.Container>
         </div>

--- a/src/components/common/bottomSheet/BottomSheetTitle/BottomSheetTitle.tsx
+++ b/src/components/common/bottomSheet/BottomSheetTitle/BottomSheetTitle.tsx
@@ -1,21 +1,15 @@
-import { Badge } from '@/components/common/ui/badge';
 import React from 'react';
 
 interface BottomSheetTitleProps {
-  tag?: string;
   title: string;
 }
 
-const BottomSheetTitle: React.FC<BottomSheetTitleProps> = ({
-  tag,
-  title,
-}: BottomSheetTitleProps) => {
+const BottomSheetTitle = ({ title }: BottomSheetTitleProps) => {
   return (
     <div className='flex items-center justify-center gap-2 border-gray4 py-5 text-center text-gray1 font-subhead'>
-      {tag && <Badge className=''>{tag}</Badge>}
       {title}
     </div>
   );
 };
 
-export default BottomSheetTitle;
+export default React.memo(BottomSheetTitle);

--- a/src/components/common/bottomSheet/CloseBtn/CloseBtn.tsx
+++ b/src/components/common/bottomSheet/CloseBtn/CloseBtn.tsx
@@ -6,7 +6,7 @@ interface CloseBtnProps {
   handleClick: () => void;
 }
 
-const CloseBtn: React.FC<CloseBtnProps> = ({ handleClick }) => {
+const CloseBtn = ({ handleClick }: CloseBtnProps) => {
   return (
     <button
       className='absolute right-1/2 top-[-70px] z-50 flex h-12 w-12 translate-x-1/2 rotate-45 items-center justify-center rounded-full bg-gray1/15 text-white'
@@ -17,4 +17,4 @@ const CloseBtn: React.FC<CloseBtnProps> = ({ handleClick }) => {
   );
 };
 
-export default CloseBtn;
+export default React.memo(CloseBtn);

--- a/src/components/common/button/Button/Button.tsx
+++ b/src/components/common/button/Button/Button.tsx
@@ -1,4 +1,5 @@
 import { Button as ButtonComponent } from '@/components/common/ui/button';
+import React from 'react';
 
 interface ButtonProps {
   /** 라벨 */
@@ -35,4 +36,4 @@ const Button = ({
   );
 };
 
-export default Button;
+export default React.memo(Button);

--- a/src/components/common/button/OpenSheetBtn/OpenSheetBtn.tsx
+++ b/src/components/common/button/OpenSheetBtn/OpenSheetBtn.tsx
@@ -1,5 +1,6 @@
 import { ArrowRightIcon, HomeIcon, PlusIcon } from '@/components/common/icon';
 import { Button } from '@/components/common/ui/button';
+import React from 'react';
 
 interface OpenSheetBtnProps {
   /** 셀렉트 버튼 title*/
@@ -10,6 +11,12 @@ interface OpenSheetBtnProps {
   icon?: React.ReactNode;
 }
 
+const ICONS = {
+  HOME: <HomeIcon width={24} height={24} />,
+  PLUS: <PlusIcon width={20} height={20} className='text-gray3' />,
+  ARROW_RIGHT: <ArrowRightIcon className='text-main' />,
+} as const;
+
 const OpenSheetBtn: React.FC<OpenSheetBtnProps> = ({
   text,
   handleClick,
@@ -18,26 +25,20 @@ const OpenSheetBtn: React.FC<OpenSheetBtnProps> = ({
 }: OpenSheetBtnProps) => {
   return (
     <Button
-      variant={type === 'housework' ? 'group' : 'group'}
+      variant='group'
       size='large'
       className='items-center !justify-between bg-white px-3'
       onClick={handleClick}
     >
       <div className='flex items-center gap-x-4'>
-        {type === 'housework' ? '' : <HomeIcon width={24} height={24} />}
+        {type === 'housework' ? '' : ICONS.HOME}
         {type === 'housework' && icon}
         <div className='text-gray3 font-body'>{text}</div>
       </div>
 
-      <div>
-        {type === 'housework' ? (
-          <PlusIcon width={20} height={20} className='text-gray3' />
-        ) : (
-          <ArrowRightIcon className='text-main' />
-        )}
-      </div>
+      <div>{type === 'housework' ? ICONS.PLUS : ICONS.ARROW_RIGHT}</div>
     </Button>
   );
 };
 
-export default OpenSheetBtn;
+export default React.memo(OpenSheetBtn);

--- a/src/components/common/button/OpenSheetBtn/OpenSheetBtnWithLabel.tsx
+++ b/src/components/common/button/OpenSheetBtn/OpenSheetBtnWithLabel.tsx
@@ -1,5 +1,6 @@
 import { CheckIcon } from '@/components/common/icon';
 import { Button } from '@/components/common/ui/button';
+import useAddHouseWorkStore from '@/store/useAddHouseWorkStore';
 import { User } from '@/types/apis/groupApi';
 
 interface OpenSheetBtnWithLabelProps {
@@ -17,9 +18,11 @@ const OpenSheetBtnWithLabel: React.FC<OpenSheetBtnWithLabelProps> = ({
   members,
   icon,
 }: OpenSheetBtnWithLabelProps) => {
+  const { nickname } = useAddHouseWorkStore();
+
   const displayValue =
     members && typeof selected === 'number'
-      ? members.find(member => member.userId === selected)?.nickName || selected
+      ? members.find(member => member.userId === selected)?.nickName || nickname
       : selected;
 
   return (

--- a/src/components/common/tab/PresetTab/PresetTabItem.tsx
+++ b/src/components/common/tab/PresetTab/PresetTabItem.tsx
@@ -14,6 +14,15 @@ interface PresetTabItemProps {
   value: string;
 }
 
+const ICONS = {
+  [Category.ALL]: <HomeIcon />,
+  [Category.LIVING_ROOM]: <LivingRoomIcon />,
+  [Category.BATH_ROOM]: <BathRoomIcon />,
+  [Category.BED_ROOM]: <BedRoomIcon />,
+  [Category.KITCHEN]: <KitchenIcon />,
+  [Category.ETC]: <EtcIcon />,
+} as const;
+
 const PresetTabItem: React.FC<PresetTabItemProps> = ({ name, value }) => {
   return (
     <TabsTrigger
@@ -21,12 +30,7 @@ const PresetTabItem: React.FC<PresetTabItemProps> = ({ name, value }) => {
       className='flex gap-2 rounded-xl px-2 py-2 font-label data-[state=active]:bg-black data-[state=inactive]:bg-gray5 data-[state=active]:text-white data-[state=inactive]:text-black'
     >
       <div className='flex h-5 items-center justify-center'>
-        {name === Category.ALL && <HomeIcon />}
-        {name === Category.LIVING_ROOM && <LivingRoomIcon />}
-        {name === Category.BATH_ROOM && <BathRoomIcon />}
-        {name === Category.BED_ROOM && <BedRoomIcon />}
-        {name === Category.KITCHEN && <KitchenIcon />}
-        {name === Category.ETC && <EtcIcon />}
+        {ICONS[name as keyof typeof ICONS]}
       </div>
       <span className='flex items-center'>{name}</span>
     </TabsTrigger>

--- a/src/components/housework/ActionButton/ActionButton.tsx
+++ b/src/components/housework/ActionButton/ActionButton.tsx
@@ -1,0 +1,27 @@
+import Button from '@/components/common/button/Button/Button';
+import { BUTTON_TITLES } from '@/constants/addHousework';
+import React from 'react';
+
+interface ActionButtonProps {
+  step: number;
+  isLoading: boolean;
+  isDisabled: boolean;
+  handleNextClick: () => void;
+}
+
+const ActionButton = ({ step, isLoading, isDisabled, handleNextClick }: ActionButtonProps) => {
+  if (isLoading) return null;
+
+  return (
+    <Button
+      variant='full'
+      size='large'
+      label={BUTTON_TITLES[step as 1 | 2]}
+      handleClick={handleNextClick}
+      disabled={isDisabled}
+      className='sticky bottom-6'
+    />
+  );
+};
+
+export default React.memo(ActionButton);

--- a/src/components/housework/HeaderWithTitle/HeaderWithTitle.tsx
+++ b/src/components/housework/HeaderWithTitle/HeaderWithTitle.tsx
@@ -6,7 +6,7 @@ export interface HeaderWithTitleProps extends BackBtnProps {
   title: React.ReactNode;
 }
 
-const HeaderWithTitle: React.FC<HeaderWithTitleProps> = ({ title, handleClick }) => {
+const HeaderWithTitle = ({ title, handleClick }: HeaderWithTitleProps) => {
   return (
     <div className='mt-5 flex flex-col gap-5'>
       <BackBtn handleClick={handleClick} />
@@ -15,4 +15,4 @@ const HeaderWithTitle: React.FC<HeaderWithTitleProps> = ({ title, handleClick })
   );
 };
 
-export default HeaderWithTitle;
+export default React.memo(HeaderWithTitle);

--- a/src/components/housework/HouseWorkSheet/HouseWorkSheet.tsx
+++ b/src/components/housework/HouseWorkSheet/HouseWorkSheet.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import BottomSheet from '@/components/common/bottomSheet/BottomSheet';
 import Button from '@/components/common/button/Button/Button';
 import PresetTab from '@/components/common/tab/PresetTab/PresetTab';
@@ -46,6 +46,8 @@ const HouseWorkSheet: React.FC<HouseWorkSheetProps> = ({
   const [selectedHouseWork, setSelectedHouseWork] = useState<string | null>(null);
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
 
+  const memoizedPresetData = useMemo(() => presetData, [presetData]);
+
   // 현재 입장한 채널
   const { channelId: strChannelId } = useParams();
   const channelId = Number(strChannelId);
@@ -81,11 +83,11 @@ const HouseWorkSheet: React.FC<HouseWorkSheetProps> = ({
     }
   };
 
-  const handleDoneClick = () => {
+  const handleDoneClick = useCallback(() => {
     setTask(selectedHouseWork ?? '');
     setCategory(selectedCategory ?? '');
     setOpen(false);
-  };
+  }, [selectedHouseWork, selectedCategory]);
 
   const handleTabChange = (value: string) => {
     setActiveTab(value);
@@ -114,7 +116,7 @@ const HouseWorkSheet: React.FC<HouseWorkSheetProps> = ({
             />
           </div>
           <PresetTab
-            presetData={presetData}
+            presetData={memoizedPresetData}
             cateActiveTab={cateActiveTab}
             setCateActiveTab={handleCateTabChange}
             isBottomSheet={true}

--- a/src/components/housework/HouseworkForm/HouseworkForm.tsx
+++ b/src/components/housework/HouseworkForm/HouseworkForm.tsx
@@ -12,6 +12,8 @@ interface HouseworkFormProps {
   handleDueDateClick: () => void;
   setTime: React.Dispatch<React.SetStateAction<SelectedTime | null>>;
   time: SelectedTime | null;
+  isAllday: boolean;
+  setIsAllday: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 const HouseworkForm: React.FC<HouseworkFormProps> = ({
@@ -21,6 +23,8 @@ const HouseworkForm: React.FC<HouseworkFormProps> = ({
   handleDueDateClick,
   setTime,
   time,
+  isAllday,
+  setIsAllday,
 }) => {
   return (
     <section className='flex flex-1 flex-col gap-4' aria-label='집안일 추가 컨텐츠'>
@@ -52,7 +56,7 @@ const HouseworkForm: React.FC<HouseworkFormProps> = ({
           icon={<DateIcon className='text-gray3' />}
         />
       )}
-      <TimeControl setTime={setTime} time={time} />
+      <TimeControl setTime={setTime} time={time} isAllday={isAllday} setIsAllday={setIsAllday} />
     </section>
   );
 };

--- a/src/components/housework/HouseworkForm/HouseworkForm.tsx
+++ b/src/components/housework/HouseworkForm/HouseworkForm.tsx
@@ -16,6 +16,17 @@ interface HouseworkFormProps {
   setIsAllday: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
+const ICONS = {
+  ETC: {
+    DEFAULT: <EtcIcon />,
+    GRAY: <EtcIcon fillOneClass='fill-gray2' fillTwoClass='fill-gray3' />,
+  },
+  DATE: {
+    DEFAULT: <DateIcon className='text-main' />,
+    GRAY: <DateIcon className='text-gray3' />,
+  },
+} as const;
+
 const HouseworkForm: React.FC<HouseworkFormProps> = ({
   task,
   startDate,
@@ -32,28 +43,28 @@ const HouseworkForm: React.FC<HouseworkFormProps> = ({
         <OpenSheetBtnWithLabel
           selected={task}
           handleClick={handleHouseWorkClick}
-          icon={<EtcIcon />}
+          icon={ICONS.ETC.DEFAULT}
         />
       ) : (
         <OpenSheetBtn
           text='어떤 집안일인가요?'
           handleClick={handleHouseWorkClick}
           type='housework'
-          icon={<EtcIcon fillOneClass='fill-gray2' fillTwoClass='fill-gray3' />}
+          icon={ICONS.ETC.GRAY}
         />
       )}
       {startDate ? (
         <OpenSheetBtnWithLabel
           selected={startDate}
           handleClick={handleDueDateClick}
-          icon={<DateIcon className='text-main' />}
+          icon={ICONS.DATE.DEFAULT}
         />
       ) : (
         <OpenSheetBtn
           text='언제 해야 하나요?'
           handleClick={handleDueDateClick}
           type='housework'
-          icon={<DateIcon className='text-gray3' />}
+          icon={ICONS.DATE.GRAY}
         />
       )}
       <TimeControl setTime={setTime} time={time} isAllday={isAllday} setIsAllday={setIsAllday} />

--- a/src/components/housework/ManagerSelectSheet/ManagerItem/ManagerItem.tsx
+++ b/src/components/housework/ManagerSelectSheet/ManagerItem/ManagerItem.tsx
@@ -52,4 +52,4 @@ const ManagerItem: React.FC<ManagerItemProps> = ({
   );
 };
 
-export default ManagerItem;
+export default React.memo(ManagerItem);

--- a/src/components/housework/ManagerSelectSheet/ManagerItem/ManagerItems.tsx
+++ b/src/components/housework/ManagerSelectSheet/ManagerItem/ManagerItems.tsx
@@ -1,5 +1,5 @@
 import ManagerItem from '@/components/housework/ManagerSelectSheet/ManagerItem/ManagerItem';
-import { Dispatch, SetStateAction } from 'react';
+import { Dispatch, SetStateAction, useCallback } from 'react';
 import { User } from '@/types/apis/groupApi';
 import useAddHouseWorkStore from '@/store/useAddHouseWorkStore';
 
@@ -18,15 +18,18 @@ const ManagerItems: React.FC<ManagerItemsProps> = ({
 }) => {
   const { setNickName } = useAddHouseWorkStore();
 
-  const handleClick = (id: number, nickname: string) => {
-    if (selectedValue === id) {
-      setSelectedValue(null); // 같은 아이템 클릭 시 선택 해제
-      setNickName('');
-    } else {
-      setSelectedValue(id); // 다른 아이템 클릭 시 선택
-      setNickName(nickname);
-    }
-  };
+  const createHandleClick = useCallback(
+    (id: number, nickname: string) => () => {
+      if (selectedValue === id) {
+        setSelectedValue(null);
+        setNickName('');
+      } else {
+        setSelectedValue(id);
+        setNickName(nickname);
+      }
+    },
+    [selectedValue, setSelectedValue, setNickName]
+  );
 
   return (
     <ul className='my-4 flex h-[220px] flex-col overflow-y-auto pt-2 no-scrollbar'>
@@ -34,7 +37,7 @@ const ManagerItems: React.FC<ManagerItemsProps> = ({
         <ManagerItem
           key={member.userId}
           name={member.nickName}
-          handleClick={() => handleClick(member.userId, member.nickName)}
+          handleClick={createHandleClick(member.userId, member.nickName)}
           selectState={selectedValue === member.userId ? 'selected' : 'default'}
         />
       ))}

--- a/src/components/housework/ManagerSelectSheet/ManagerItem/ManagerItems.tsx
+++ b/src/components/housework/ManagerSelectSheet/ManagerItem/ManagerItems.tsx
@@ -1,6 +1,7 @@
 import ManagerItem from '@/components/housework/ManagerSelectSheet/ManagerItem/ManagerItem';
 import { Dispatch, SetStateAction } from 'react';
 import { User } from '@/types/apis/groupApi';
+import useAddHouseWorkStore from '@/store/useAddHouseWorkStore';
 
 interface ManagerItemsProps {
   // isAiCardOpen: boolean;
@@ -15,11 +16,15 @@ const ManagerItems: React.FC<ManagerItemsProps> = ({
   selectedValue,
   members,
 }) => {
-  const handleClick = (id: number) => {
+  const { setNickName } = useAddHouseWorkStore();
+
+  const handleClick = (id: number, nickname: string) => {
     if (selectedValue === id) {
       setSelectedValue(null); // 같은 아이템 클릭 시 선택 해제
+      setNickName('');
     } else {
       setSelectedValue(id); // 다른 아이템 클릭 시 선택
+      setNickName(nickname);
     }
   };
 
@@ -29,7 +34,7 @@ const ManagerItems: React.FC<ManagerItemsProps> = ({
         <ManagerItem
           key={member.userId}
           name={member.nickName}
-          handleClick={() => handleClick(member.userId)}
+          handleClick={() => handleClick(member.userId, member.nickName)}
           selectState={selectedValue === member.userId ? 'selected' : 'default'}
         />
       ))}

--- a/src/components/housework/ManagerSelectSheet/ManagerSelectSheet.tsx
+++ b/src/components/housework/ManagerSelectSheet/ManagerSelectSheet.tsx
@@ -58,7 +58,7 @@ const ManagerSelectSheet: React.FC<ManagerSelectSheetProps> = ({
             size='small'
             handleClick={handleClick}
           /> */}
-          <Button label='확인' variant='full' size='small' handleClick={handleDoneClick} />
+          <Button label='확인' variant='full' size='large' handleClick={handleDoneClick} />
         </div>
       </div>
     </BottomSheet>

--- a/src/components/housework/TaskAssignmentContent/TaskAssignmentContent.tsx
+++ b/src/components/housework/TaskAssignmentContent/TaskAssignmentContent.tsx
@@ -10,6 +10,13 @@ interface TaskAssignmentContentProps {
   handleManagerClick: () => void;
 }
 
+const ICONS = {
+  PROFILE: {
+    DEFAULT: <ProfileIcon className='text-main' />,
+    GRAY: <ProfileIcon className='text-gray3' />,
+  },
+} as const;
+
 const TaskAssignmentContent: React.FC<TaskAssignmentContentProps> = ({
   userId,
   members,
@@ -23,14 +30,14 @@ const TaskAssignmentContent: React.FC<TaskAssignmentContentProps> = ({
             selected={userId}
             handleClick={handleManagerClick}
             members={members}
-            icon={<ProfileIcon className='text-main' />}
+            icon={ICONS.PROFILE.DEFAULT}
           />
         ) : (
           <OpenSheetBtn
             text='책임자는 누구인가요?'
             handleClick={handleManagerClick}
             type='housework'
-            icon={<ProfileIcon className='text-gray3' />}
+            icon={ICONS.PROFILE.GRAY}
           />
         )}
       </section>

--- a/src/components/housework/TimeControl/TimeControl.tsx
+++ b/src/components/housework/TimeControl/TimeControl.tsx
@@ -1,8 +1,8 @@
-import { Label } from '@/components/common/ui/label';
 import { Switch } from '@/components/common/ui/switch';
 import TimePicker from '@/components/housework/TimeControl/TimePicker/TimePicker';
 import { cn } from '@/lib/utils';
-import { ClockIcon } from '@/components/common/icon';
+import TimeLabel from '@/components/housework/TimeLabel/TimeLabel'; // TimeLabel 컴포넌트 import
+import React from 'react';
 
 interface SelectedTime {
   hour: string;
@@ -20,11 +20,9 @@ interface TimeControlProps {
 const TimeControl = ({ setTime, time, isAllday, setIsAllday }: TimeControlProps) => {
   const handleSwitchChange = () => {
     if (!isAllday) {
-      //false때 누르면 하루종일하기가 활성화
       setIsAllday(true);
       setTime(null);
     } else {
-      //true일때 누르면 하루종일하기가 비활성화
       setIsAllday(false);
     }
   };
@@ -37,21 +35,7 @@ const TimeControl = ({ setTime, time, isAllday, setIsAllday }: TimeControlProps)
       )}
     >
       <div className='flex items-center justify-between text-black font-body'>
-        {isAllday ? (
-          <Label htmlFor='time-mode' className='flex items-center gap-4'>
-            <ClockIcon
-              fillClass='fill-main'
-              circleStrokeClass='stroke-main'
-              handStrokeClass='stroke-white'
-            />
-            <p>하루종일 하기</p>
-          </Label>
-        ) : (
-          <Label htmlFor='time-mode' className='text-gray flex items-center gap-4'>
-            <ClockIcon />
-            <p>시작시간이 언제인가요?</p>
-          </Label>
-        )}
+        <TimeLabel isAllday={isAllday} />
         <Switch
           id='time-mode'
           checked={isAllday}
@@ -64,4 +48,4 @@ const TimeControl = ({ setTime, time, isAllday, setIsAllday }: TimeControlProps)
   );
 };
 
-export default TimeControl;
+export default React.memo(TimeControl);

--- a/src/components/housework/TimeControl/TimeControl.tsx
+++ b/src/components/housework/TimeControl/TimeControl.tsx
@@ -1,7 +1,6 @@
 import { Label } from '@/components/common/ui/label';
 import { Switch } from '@/components/common/ui/switch';
 import TimePicker from '@/components/housework/TimeControl/TimePicker/TimePicker';
-import useAddHouseWorkStore from '@/store/useAddHouseWorkStore';
 import { cn } from '@/lib/utils';
 import { ClockIcon } from '@/components/common/icon';
 
@@ -14,11 +13,11 @@ interface SelectedTime {
 interface TimeControlProps {
   setTime: React.Dispatch<React.SetStateAction<SelectedTime | null>>;
   time: SelectedTime | null;
+  isAllday: boolean;
+  setIsAllday: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
-const TimeControl = ({ setTime, time }: TimeControlProps) => {
-  const { isAllday, setIsAllday } = useAddHouseWorkStore();
-
+const TimeControl = ({ setTime, time, isAllday, setIsAllday }: TimeControlProps) => {
   const handleSwitchChange = () => {
     if (!isAllday) {
       //false때 누르면 하루종일하기가 활성화

--- a/src/components/housework/TimeLabel/TimeLabel.tsx
+++ b/src/components/housework/TimeLabel/TimeLabel.tsx
@@ -1,0 +1,34 @@
+import { ClockIcon } from '@/components/common/icon';
+import { Label } from '@/components/common/ui/label';
+import React from 'react';
+
+interface TimeLabelProps {
+  isAllday: boolean;
+}
+
+const ICONS = {
+  CLOCK: {
+    DEFAULT: <ClockIcon />,
+    ACTIVE: (
+      <ClockIcon
+        fillClass='fill-main'
+        circleStrokeClass='stroke-main'
+        handStrokeClass='stroke-white'
+      />
+    ),
+  },
+} as const;
+
+const TimeLabel = ({ isAllday }: TimeLabelProps) => {
+  return (
+    <Label
+      htmlFor='time-mode'
+      className={`flex items-center gap-4 ${!isAllday ? 'text-gray' : ''}`}
+    >
+      {isAllday ? ICONS.CLOCK.ACTIVE : ICONS.CLOCK.DEFAULT}
+      <p>{isAllday ? '하루종일 하기' : '시작시간이 언제인가요?'}</p>
+    </Label>
+  );
+};
+
+export default React.memo(TimeLabel);

--- a/src/components/housework/steps/Step1.tsx
+++ b/src/components/housework/steps/Step1.tsx
@@ -9,6 +9,8 @@ interface Step1Props {
   setCategory: React.Dispatch<React.SetStateAction<string>>;
   startDate: string;
   setStartDate: React.Dispatch<React.SetStateAction<string>>;
+  isAllday: boolean;
+  setIsAllday: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 const Step1 = ({
@@ -19,6 +21,8 @@ const Step1 = ({
   setCategory,
   startDate,
   setStartDate,
+  isAllday,
+  setIsAllday,
 }: Step1Props) => {
   const {
     handleHouseWorkClick,
@@ -37,6 +41,8 @@ const Step1 = ({
         handleDueDateClick={handleDueDateClick}
         setTime={setTime}
         time={time}
+        isAllday={isAllday}
+        setIsAllday={setIsAllday}
       />
 
       <HouseWorkSheet

--- a/src/components/housework/steps/Step1.tsx
+++ b/src/components/housework/steps/Step1.tsx
@@ -1,5 +1,6 @@
 import { DueDateSheet, HouseworkForm, HouseWorkSheet } from '@/components/housework';
-import useAddHouseWork, { SelectedTime } from '@/hooks/useAddHouseWork';
+import { SelectedTime } from '@/hooks/useAddHouseWork';
+import React, { useState } from 'react';
 
 interface Step1Props {
   setTime: React.Dispatch<React.SetStateAction<SelectedTime | null>>;
@@ -24,14 +25,17 @@ const Step1 = ({
   isAllday,
   setIsAllday,
 }: Step1Props) => {
-  const {
-    handleHouseWorkClick,
-    handleDueDateClick,
-    isHouseWorkSheetOpen,
-    setHouseWorkSheetOpen,
-    isDueDateSheetOpen,
-    setDueDateSheetOpen,
-  } = useAddHouseWork();
+  const [isHouseWorkSheetOpen, setHouseWorkSheetOpen] = useState(false);
+  const [isDueDateSheetOpen, setDueDateSheetOpen] = useState(false);
+
+  //바텀 시트 여는 함수들
+  const handleHouseWorkClick = () => {
+    setHouseWorkSheetOpen(true);
+  };
+
+  const handleDueDateClick = () => {
+    setDueDateSheetOpen(true);
+  };
   return (
     <>
       <HouseworkForm

--- a/src/constants/addHousework.ts
+++ b/src/constants/addHousework.ts
@@ -1,0 +1,9 @@
+export const STEP_TITLES = {
+  1: '새로운 집안일을\n추가해보세요',
+  2: '담당자를\n지정해보세요',
+};
+
+export const BUTTON_TITLES = {
+  1: '다음',
+  2: '완료',
+};

--- a/src/hooks/useAddHouseWork.ts
+++ b/src/hooks/useAddHouseWork.ts
@@ -1,7 +1,6 @@
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import useAddHouseWorkStore from '@/store/useAddHouseWorkStore';
-import { User } from '@/types/apis/groupApi';
 import { getGroupUser } from '@/services/group/getGroupUser';
 import { putHousework } from '@/services/housework/putHousework';
 import { postHousework } from '@/services/housework/postHousework';
@@ -24,7 +23,16 @@ const useAddHouseWork = () => {
   const houseworkId = Number(strHouseworkId);
 
   //전역 상태
-  const { userId, setUserId, reset, setNickName, targetHousework } = useAddHouseWorkStore();
+  const {
+    userId,
+    setUserId,
+    reset,
+    setNickName,
+    targetHousework,
+    members,
+    setMembers,
+    setIsMemberLoading,
+  } = useAddHouseWorkStore();
 
   const { setActiveDate, setActiveWeek, setActiveTab, setWeekText } = useHomePageStore();
 
@@ -53,8 +61,6 @@ const useAddHouseWork = () => {
 
   //담당자 시트 관리하는 지역 상태
   const [selectedValue, setSelectedValue] = useState(userId || null);
-  const [members, setMembers] = useState<User[]>([]);
-  const [isMemberLoading, setIsMemberLoading] = useState(true);
 
   const memoizedMembers = useMemo(() => members, [members]);
 
@@ -70,19 +76,21 @@ const useAddHouseWork = () => {
 
   //멤버 조회하는 api 호출
   useEffect(() => {
+    if (step !== 2) return;
+
     const fetchGroupMembers = async () => {
       try {
         const response = await getGroupUser({ channelId });
-        setMembers(response.result.userList);
+        setMembers(response.result.userList); // 전역 상태 업데이트
+        setIsMemberLoading(false);
       } catch (error) {
         console.error('그룹 사용자 조회 실패:', error);
-      } finally {
         setIsMemberLoading(false);
       }
     };
 
     fetchGroupMembers();
-  }, [channelId]);
+  }, [channelId, step]);
 
   const handleBackClick = useCallback(() => {
     if (step === 1) {
@@ -175,7 +183,6 @@ const useAddHouseWork = () => {
     category,
     task,
     setTask,
-    isMemberLoading,
     isLoading,
     members: memoizedMembers,
     handleManagerClick,

--- a/src/hooks/useAddHouseWork.ts
+++ b/src/hooks/useAddHouseWork.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { useLocation, useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router-dom';
 import useAddHouseWorkStore from '@/store/useAddHouseWorkStore';
 import { User } from '@/types/apis/groupApi';
 import { getGroupUser } from '@/services/group/getGroupUser';
@@ -16,7 +16,6 @@ export interface SelectedTime {
 }
 
 const useAddHouseWork = () => {
-  const location = useLocation();
   const navigate = useNavigate();
 
   //채널 id와 집안일 id
@@ -24,11 +23,8 @@ const useAddHouseWork = () => {
   const channelId = Number(strChannelId);
   const houseworkId = Number(strHouseworkId);
 
-  //home에서 가져온 집안일 정보(집안일 수정에서 사용할 거임)
-  const targetHousework = location.state;
-
   //전역 상태
-  const { userId, setIsAllday, setUserId, reset } = useAddHouseWorkStore();
+  const { userId, setUserId, reset, setNickName, targetHousework } = useAddHouseWorkStore();
 
   const { setActiveDate, setActiveWeek, setActiveTab, setWeekText } = useHomePageStore();
 
@@ -41,9 +37,16 @@ const useAddHouseWork = () => {
       : null
   );
 
-  const [task, setTask] = useState('');
-  const [category, setCategory] = useState('');
-  const [startDate, setStartDate] = useState('');
+  const [task, setTask] = useState(targetHousework?.task || '');
+  const [category, setCategory] = useState(targetHousework?.category || '');
+  const [startDate, setStartDate] = useState(() => {
+    if (targetHousework?.startDate) {
+      const date = new Date(targetHousework.startDate);
+      return `${date.getFullYear()}년 ${date.getMonth() + 1}월 ${date.getDate()}일`;
+    }
+    return '';
+  });
+  const [isAllday, setIsAllday] = useState((targetHousework?.isAllDay as boolean) ?? true);
 
   //담당자 선택 시트 오픈 여부
   const [isOpen, setIsOpen] = useState(false);
@@ -58,18 +61,10 @@ const useAddHouseWork = () => {
   //패널 : 스텝
   const [step, setStep] = useState(1);
 
-  //home에서 가져온 집안일이 있을 경우 전역 상태에 값들을 채워준다
   useEffect(() => {
     if (targetHousework) {
-      setTask(targetHousework.task);
-
-      const date = new Date(targetHousework.startDate);
-      const formattedDate = `${date.getFullYear()}년 ${date.getMonth() + 1}월 ${date.getDate()}일`;
-
-      setStartDate(formattedDate);
-      setCategory(targetHousework.category);
       setUserId(targetHousework.userId);
-      setIsAllday(targetHousework.isAllDay);
+      setNickName(targetHousework.assignee);
     }
   }, []);
 
@@ -215,6 +210,8 @@ const useAddHouseWork = () => {
     setTime,
     setCategory,
     setStartDate,
+    isAllday,
+    setIsAllday,
   };
 };
 

--- a/src/hooks/useHomePage.ts
+++ b/src/hooks/useHomePage.ts
@@ -17,6 +17,7 @@ import { getMyInfo } from '@/services/user/getMyInfo';
 import { getWeeklyIncomplete } from '@/services/housework/getWeeklyIncomplete';
 import { postCompliment } from '@/services/noticeManage/postCompliment';
 import { postPoke } from '@/services/noticeManage/postPoke';
+import useAddHouseWorkStore from '@/store/useAddHouseWorkStore';
 
 export const useHomePage = () => {
   const {
@@ -30,6 +31,8 @@ export const useHomePage = () => {
     setMyInfo,
     setCurrWeek,
   } = useHomePageStore();
+
+  const { setTargetHousework } = useAddHouseWorkStore();
 
   const { channelId: channelIdStr } = useParams();
   const channelId = Number(channelIdStr);
@@ -177,9 +180,8 @@ export const useHomePage = () => {
       if (targetHousework?.status === HOUSEWORK_STATUS.COMPLETE) {
         toast({ title: '완료한 집안일은 수정할 수 없어요' });
       } else {
-        navigate(`/add-housework/edit/${channelId}/${houseworkId}`, {
-          state: targetHousework,
-        });
+        setTargetHousework(targetHousework);
+        navigate(`/add-housework/edit/${channelId}/${houseworkId}`);
       }
     },
     [houseworks, navigate, channelId, toast]

--- a/src/pages/housework/AddHouseworkPage.tsx
+++ b/src/pages/housework/AddHouseworkPage.tsx
@@ -1,7 +1,9 @@
 import MetaTags from '@/components/common/metaTags/MetaTags';
 import { HeaderWithTitle, Step1, Step2, HouseWorkAddLoading } from '@/components/housework';
-import Button from '@/components/common/button/Button/Button';
 import useAddHouseWork from '@/hooks/useAddHouseWork';
+import { STEP_TITLES } from '@/constants/addHousework';
+import { useMemo } from 'react';
+import ActionButton from '@/components/housework/ActionButton/ActionButton';
 
 const AddHouseworkPage = ({}) => {
   const {
@@ -25,6 +27,11 @@ const AddHouseworkPage = ({}) => {
     setIsAllday,
   } = useAddHouseWork();
 
+  const isDisabled = useMemo(
+    () => (step === 1 ? !task || !startDate : !userId),
+    [step, task, startDate, userId]
+  );
+
   return (
     <div className='flex h-screen flex-col gap-4 px-5 pb-6'>
       {houseworkId ? (
@@ -41,10 +48,7 @@ const AddHouseworkPage = ({}) => {
         />
       )}
       {!isLoading && (
-        <HeaderWithTitle
-          title={step === 1 ? `새로운 집안일을\n추가해보세요` : `담당자를\n지정해보세요`}
-          handleClick={handleBackClick}
-        />
+        <HeaderWithTitle title={STEP_TITLES[step as 1 | 2]} handleClick={handleBackClick} />
       )}
 
       {/* 집안일,날짜,시간 */}
@@ -76,16 +80,12 @@ const AddHouseworkPage = ({}) => {
           <Step2 />
         ))}
 
-      {!isLoading && (
-        <Button
-          variant='full'
-          size='large'
-          label={step === 1 ? '다음' : '완료'}
-          handleClick={handleNextClick}
-          disabled={step === 1 ? !task || !startDate : !userId}
-          className='sticky bottom-6'
-        />
-      )}
+      <ActionButton
+        step={step}
+        isLoading={isLoading}
+        isDisabled={isDisabled}
+        handleNextClick={handleNextClick}
+      />
     </div>
   );
 };

--- a/src/pages/housework/AddHouseworkPage.tsx
+++ b/src/pages/housework/AddHouseworkPage.tsx
@@ -21,9 +21,9 @@ const AddHouseworkPage = ({}) => {
     category,
     setCategory,
     setStartDate,
+    isAllday,
+    setIsAllday,
   } = useAddHouseWork();
-
-  console.log(task, category);
 
   return (
     <div className='flex h-screen flex-col gap-4 px-5 pb-6'>
@@ -57,6 +57,8 @@ const AddHouseworkPage = ({}) => {
           setCategory={setCategory}
           startDate={startDate}
           setStartDate={setStartDate}
+          isAllday={isAllday}
+          setIsAllday={setIsAllday}
         />
       )}
 

--- a/src/store/useAddHouseWorkStore.ts
+++ b/src/store/useAddHouseWorkStore.ts
@@ -1,6 +1,7 @@
 import { Housework } from '@/types/apis/houseworkApi';
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
+import { User } from '@/types/apis/groupApi';
 
 interface AddHouseWorkState {
   userId: number | null;
@@ -8,6 +9,8 @@ interface AddHouseWorkState {
   selectedDate: Date | undefined;
   nickname: string;
   targetHousework: Housework | undefined;
+  members: User[];
+  isMemberLoading: boolean;
 }
 
 interface AddHouseWorkActions {
@@ -16,6 +19,8 @@ interface AddHouseWorkActions {
   setSelectedDate: (date: Date | undefined) => void;
   setNickName: (nickname: string) => void;
   setTargetHousework: (targetHousework: Housework | undefined) => void;
+  setMembers: (members: User[]) => void;
+  setIsMemberLoading: (isMemberLoading: boolean) => void;
   reset: () => void;
 }
 
@@ -25,6 +30,8 @@ const initialState: AddHouseWorkState = {
   selectedDate: undefined,
   nickname: '',
   targetHousework: undefined,
+  members: [],
+  isMemberLoading: true,
 };
 
 type State = AddHouseWorkState & AddHouseWorkActions;
@@ -39,6 +46,8 @@ const useAddHouseWorkStore = create<State>()(
       setSelectedDate: selectedDate => set({ selectedDate }),
       setNickName: nickname => set({ nickname }),
       setTargetHousework: targetHousework => set({ targetHousework }),
+      setMembers: members => set({ members }),
+      setIsMemberLoading: isMemberLoading => set({ isMemberLoading }),
       reset: () => set(initialState),
     }),
     {

--- a/src/store/useAddHouseWorkStore.ts
+++ b/src/store/useAddHouseWorkStore.ts
@@ -1,35 +1,53 @@
+import { Housework } from '@/types/apis/houseworkApi';
 import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
 
 interface AddHouseWorkState {
-  isAllday: boolean;
   userId: number | null;
   selectedItem: number | null;
   selectedDate: Date | undefined;
+  nickname: string;
+  targetHousework: Housework | undefined;
 }
 
 interface AddHouseWorkActions {
-  setIsAllday: (value: boolean) => void;
   setUserId: (id: number | null) => void;
   setSelectedItem: (itemId: number | null) => void;
   setSelectedDate: (date: Date | undefined) => void;
+  setNickName: (nickname: string) => void;
+  setTargetHousework: (targetHousework: Housework | undefined) => void;
   reset: () => void;
 }
 
 const initialState: AddHouseWorkState = {
-  isAllday: true,
   userId: null,
   selectedItem: null,
   selectedDate: undefined,
+  nickname: '',
+  targetHousework: undefined,
 };
 
-const useAddHouseWorkStore = create<AddHouseWorkState & AddHouseWorkActions>(set => ({
-  ...initialState,
+type State = AddHouseWorkState & AddHouseWorkActions;
+type PersistedState = Pick<AddHouseWorkState, 'targetHousework'>;
 
-  setIsAllday: isAllday => set({ isAllday }),
-  setUserId: userId => set({ userId }),
-  setSelectedItem: selectedItem => set({ selectedItem }),
-  setSelectedDate: selectedDate => set({ selectedDate }),
-  reset: () => set(initialState),
-}));
+const useAddHouseWorkStore = create<State>()(
+  persist(
+    set => ({
+      ...initialState,
+      setUserId: userId => set({ userId }),
+      setSelectedItem: selectedItem => set({ selectedItem }),
+      setSelectedDate: selectedDate => set({ selectedDate }),
+      setNickName: nickname => set({ nickname }),
+      setTargetHousework: targetHousework => set({ targetHousework }),
+      reset: () => set(initialState),
+    }),
+    {
+      name: 'housework-storage',
+      partialize: (state): PersistedState => ({
+        targetHousework: state.targetHousework,
+      }),
+    }
+  )
+);
 
 export default useAddHouseWorkStore;


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

> 집안일 추가 수정 렌더링 회적화

## 📌 이슈 넘버

- [x] #23 

## 📝 작업 내용

usecallback, usememo, react.memo, 상수화로 렌더링 최적화를 해봤습니다.

<img width="555" alt="KakaoTalk_20250103_140136268" src="https://github.com/user-attachments/assets/242f7a9e-c939-4387-9d42-cc30f9b3c288" />
<img width="556" alt="KakaoTalk_20250103_140413824" src="https://github.com/user-attachments/assets/f33b4305-c240-4c39-82ab-12c0507bd4c0" />

addhouseworkPage의 첫번째 커밋의 duration을 1.6ms of 20ms에서  0.4ms of 14.8ms로 줄였습니다.
렌더링 횟수도 3회에서 1회로 감소했습니다.

(첫 번째 커밋의 duration을 보는 것은 특히 중요한데, 이는 초기 렌더링 성능을 나타내기 때문입니다. 첫 렌더링에서는 React가 루트 컴포넌트부터 시작해서 모든 컴포넌트를 처음으로 렌더링하게 됩니다)


----


그리고 naviagate에서 targethousework를 전달하는 게 아닌
전역변수로 관리하도록 바꿨습니다. (persist를 사용해서 새로고침해도 안날라가도록 설정했습니다.)

## 📸 스크린샷(선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
