### PR TITLE
Feature/#46 - 프리셋 설정 페이지 성능 최적화

### DIFF
--- a/src/components/common/preset/PresetItem.tsx
+++ b/src/components/common/preset/PresetItem.tsx
@@ -2,29 +2,29 @@ import { BinIcon } from '@/components/common/icon';
 import HouseworkCategoryTag, {
   HouseworkCategoryTagProps,
 } from '@/components/common/tag/HouseworkCatetoryTag/HouseworkCategoryTag';
-import React from 'react';
+import { memo } from 'react';
 
 export interface PresetItemProps extends HouseworkCategoryTagProps {
   housework: string;
-  handleSelectClick?: () => void;
   isPresetSettingCustom?: boolean;
   isShowDeleteBtn?: boolean;
-  handleSettingClick?: () => void;
-  handleDeleteClick?: () => void;
   isSelected?: boolean;
   isBottomSheet?: boolean;
+  handleSelectClick?: () => void;
+  handleSettingClick?: () => void;
+  handleDeleteClick?: () => void;
 }
 
-const PresetItem: React.FC<PresetItemProps> = ({
+const PresetItem = ({
   category,
   housework,
-  handleSelectClick,
   isPresetSettingCustom,
   isShowDeleteBtn,
-  handleDeleteClick,
   isSelected,
   isBottomSheet,
-}) => {
+  handleSelectClick,
+  handleDeleteClick,
+}: PresetItemProps) => {
   return (
     <li
       className={`flex flex-1 cursor-pointer list-none items-center justify-between border-b-[1px] border-solid border-white pl-5 ${
@@ -52,4 +52,4 @@ const PresetItem: React.FC<PresetItemProps> = ({
   );
 };
 
-export default PresetItem;
+export default memo(PresetItem);

--- a/src/components/common/tab/PresetTab/PresetTab.tsx
+++ b/src/components/common/tab/PresetTab/PresetTab.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import PresetItem from '@/components/common/preset/PresetItem';
 import PresetTabItem from '@/components/common/tab/PresetTab/PresetTabItem';
 import { Tabs, TabsContent, TabsList } from '@/components/common/ui/tabs';
@@ -25,13 +26,13 @@ interface PresetTabProps {
   setCateActiveTab?: (cateActiveTab: string) => void;
   isPresetSettingCustom?: boolean;
   deleteButtonStates?: Record<number, boolean>;
-  handleDeleteClick?: (presetCategoryId: number, itemId: number) => void;
   isBottomSheet?: boolean;
-  handleClick?: (id: number, description: string, category: string) => void;
   selectedItem?: number | null;
+  handleDeleteClick?: (presetCategoryId: number, itemId: number) => void;
+  handleClick?: (id: number, description: string, category: string) => void;
 }
 
-const PresetTab: React.FC<PresetTabProps> = ({
+const PresetTab = ({
   presetData,
   cateActiveTab,
   setCateActiveTab,
@@ -41,7 +42,7 @@ const PresetTab: React.FC<PresetTabProps> = ({
   isBottomSheet = false,
   handleClick,
   selectedItem,
-}) => {
+}: PresetTabProps) => {
   const allPresetData = {
     category: PresetCategory.ALL,
     items: presetData.flatMap(categoryList =>
@@ -146,4 +147,4 @@ const PresetTab: React.FC<PresetTabProps> = ({
   );
 };
 
-export default PresetTab;
+export default memo(PresetTab);

--- a/src/components/common/tab/PresetTab/PresetTabItem.tsx
+++ b/src/components/common/tab/PresetTab/PresetTabItem.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import {
   BathRoomIcon,
   BedRoomIcon,
@@ -23,7 +24,7 @@ const ICONS = {
   [Category.ETC]: <EtcIcon />,
 } as const;
 
-const PresetTabItem: React.FC<PresetTabItemProps> = ({ name, value }) => {
+const PresetTabItem = ({ name, value }: PresetTabItemProps) => {
   return (
     <TabsTrigger
       value={value}
@@ -37,4 +38,4 @@ const PresetTabItem: React.FC<PresetTabItemProps> = ({ name, value }) => {
   );
 };
 
-export default PresetTabItem;
+export default memo(PresetTabItem);

--- a/src/components/common/tab/Tab/Tab.tsx
+++ b/src/components/common/tab/Tab/Tab.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { memo } from 'react';
 import { Tabs, TabsList } from '@/components/common/ui/tabs';
 import TabItem from '@/components/common/tab/Tab/TabItem';
 
@@ -12,7 +12,7 @@ export interface TabProps {
   chargers: Charger[];
 }
 
-const Tab: React.FC<TabProps> = ({ activeTab, handleSetActiveTab, chargers }) => {
+const Tab = ({ activeTab, handleSetActiveTab, chargers }: TabProps) => {
   return (
     <Tabs defaultValue={activeTab} onValueChange={handleSetActiveTab} value={activeTab}>
       <TabsList className='h-15 flex w-full justify-start overflow-x-auto overflow-y-hidden rounded-none bg-white p-0 no-scrollbar'>
@@ -24,4 +24,4 @@ const Tab: React.FC<TabProps> = ({ activeTab, handleSetActiveTab, chargers }) =>
   );
 };
 
-export default Tab;
+export default memo(Tab);

--- a/src/components/setting/presetSetting/PresetAddInput.stories.ts
+++ b/src/components/setting/presetSetting/PresetAddInput.stories.ts
@@ -22,8 +22,5 @@ const mockCategoryList = [
 export const Default: Story = {
   args: {
     categoryList: mockCategoryList,
-    handleAddInput: (inputVal: string, categoryId: number) => {
-      console.log(`Added "${inputVal}" to category ID: ${categoryId}`);
-    },
   },
 };

--- a/src/components/setting/presetSetting/PresetAddInput.tsx
+++ b/src/components/setting/presetSetting/PresetAddInput.tsx
@@ -1,9 +1,9 @@
 import PresetCategory from '@/components/setting/presetSetting/PresetCategory';
-import React, { useEffect } from 'react';
+import { useEffect, memo } from 'react';
 import { Category } from '@/constants';
 import usePresetSettingStore from '@/store/usePresetSettingStore';
+import usePresetSetting from '@/hooks/usePresetSetting';
 import EnterIcon from '@/components/common/icon/EnterIcon';
-import { INPUT_VALIDATION } from '@/constants/validation';
 
 interface Category {
   presetCategoryId: number;
@@ -11,50 +11,19 @@ interface Category {
 }
 interface PresetAddInputProps {
   categoryList: Category[];
-  handleAddInput: (inputVal: string, categoryId: number) => void;
 }
 
-const PresetAddInput: React.FC<PresetAddInputProps> = ({ categoryList, handleAddInput }) => {
-  const {
-    inputVal,
-    setInputVal,
-    activeInputCate,
-    setActiveInputCate,
-    activeInputCateId,
-    setActiveInputCateId,
-  } = usePresetSettingStore();
+const PresetAddInput = ({ categoryList }: PresetAddInputProps) => {
+  const { inputVal, activeInputCate, setActiveInputCate, setActiveInputCateId } =
+    usePresetSettingStore();
+  const { handleInputCateClick, handleInputChange, handleKeyDown, handleIconClick } =
+    usePresetSetting();
 
   // 첫번째 카테고리 활성화
   useEffect(() => {
     setActiveInputCate(categoryList[0].category);
     setActiveInputCateId(categoryList[0].presetCategoryId);
   }, [categoryList, setActiveInputCate, setActiveInputCateId]);
-
-  const handleInputCateClick = (cate: string, cateId: number) => {
-    setActiveInputCate(cate);
-    setActiveInputCateId(cateId);
-  };
-
-  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const value = e.target.value;
-    if (value.length <= INPUT_VALIDATION.preset.maxLength) {
-      setInputVal(value);
-    }
-  };
-
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'Enter' && inputVal.trim()) {
-      handleAddInput(inputVal, activeInputCateId);
-      setInputVal('');
-    }
-  };
-
-  const handleIconClick = () => {
-    if (inputVal.trim()) {
-      handleAddInput(inputVal, activeInputCateId);
-      setInputVal('');
-    }
-  };
 
   return (
     <div className='flex flex-col gap-4 rounded-t-2xl bg-gray5 px-5 pb-8 pt-3 text-white shadow-[0_0px_6px_-1px_rgba(0,0,0,0.1)] font-body'>
@@ -81,4 +50,4 @@ const PresetAddInput: React.FC<PresetAddInputProps> = ({ categoryList, handleAdd
   );
 };
 
-export default PresetAddInput;
+export default memo(PresetAddInput);

--- a/src/components/setting/presetSetting/PresetCategory.tsx
+++ b/src/components/setting/presetSetting/PresetCategory.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { memo } from 'react';
 
 interface Category {
   presetCategoryId: number;
@@ -6,15 +6,11 @@ interface Category {
 }
 interface PresetCategoryProps {
   activeCate: string;
-  handleCateClick: (cate: string, categoryId: number) => void;
   categoryList: Category[];
+  handleCateClick: (cate: string, categoryId: number) => void;
 }
 
-const PresetCategory: React.FC<PresetCategoryProps> = ({
-  activeCate,
-  handleCateClick,
-  categoryList,
-}) => {
+const PresetCategory = ({ activeCate, handleCateClick, categoryList }: PresetCategoryProps) => {
   return (
     <div className='flex gap-1'>
       {categoryList.map(item => (
@@ -30,4 +26,4 @@ const PresetCategory: React.FC<PresetCategoryProps> = ({
   );
 };
 
-export default PresetCategory;
+export default memo(PresetCategory);

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -9,3 +9,4 @@ export {
   DUMMY_RESULT,
 } from '@/constants/onBoarding';
 export { WEEKLY_STAT_STEP } from '@/constants/weeklyStatStep';
+export { INPUT_VALIDATION } from '@/constants/validation';

--- a/src/hooks/usePresetSetting.ts
+++ b/src/hooks/usePresetSetting.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useCallback } from 'react';
 import {
   deletePresetItem,
   getAllCategoryName,
@@ -7,7 +7,7 @@ import {
 } from '@/services/preset';
 import usePresetSettingStore from '@/store/usePresetSettingStore';
 import { useNavigate, useParams } from 'react-router-dom';
-import { Category, PresetDefault, PresetTabName } from '@/constants';
+import { Category, PresetDefault, PresetTabName, INPUT_VALIDATION } from '@/constants';
 
 const usePresetSetting = () => {
   const navigate = useNavigate();
@@ -20,12 +20,19 @@ const usePresetSetting = () => {
     selectedItem,
     setSelectedItem,
     setCateActiveTab,
+    inputVal,
+    setInputVal,
+    setActiveInputCate,
+    activeInputCateId,
+    setActiveInputCateId,
   } = usePresetSettingStore();
+
   const { channelId: strChannelId } = useParams();
   const channelId = Number(strChannelId);
 
   useEffect(() => {
     initCategoryList();
+    setDeleteButtonStates(null);
   }, []);
 
   const initCategoryList = async () => {
@@ -57,56 +64,100 @@ const usePresetSetting = () => {
     }
   };
 
-  const handleAddInput = async (name: string, presetCategoryId: number) => {
-    try {
-      await postCreatePresetItem({
-        channelId,
-        presetCategoryId,
-        name,
-      });
-      // 업데이트된 아이템 리스트 조회
-      await getPresetData();
-      setCateActiveTab(Category.ALL);
-    } catch (error) {
-      console.error('프리셋 아이템 추가 실패: ', error);
-    }
-  };
+  const handleAddInput = useCallback(
+    async (name: string, presetCategoryId: number) => {
+      try {
+        await postCreatePresetItem({
+          channelId,
+          presetCategoryId,
+          name,
+        });
+        // 업데이트된 아이템 리스트 조회
+        await getPresetData();
+        setCateActiveTab(Category.ALL);
+      } catch (error) {
+        console.error('프리셋 아이템 추가 실패: ', error);
+      }
+    },
+    [postCreatePresetItem, getPresetData]
+  );
 
-  const handleSelectClick = (presetItemId: number) => {
-    const isDeselecting = selectedItem === presetItemId;
-    setSelectedItem(isDeselecting ? null : presetItemId);
-    setDeleteButtonStates(isDeselecting ? null : presetItemId);
-  };
+  const handleSelectClick = useCallback(
+    (presetItemId: number) => {
+      const isDeselecting = selectedItem === presetItemId;
+      setSelectedItem(isDeselecting ? null : presetItemId);
+      setDeleteButtonStates(isDeselecting ? null : presetItemId);
+    },
+    [selectedItem]
+  );
 
-  const handleDeleteClick = async (presetCategoryId: number, presetItemId: number) => {
-    setDeleteButtonStates(null);
+  const handleDeleteClick = useCallback(
+    async (presetCategoryId: number, presetItemId: number) => {
+      setDeleteButtonStates(null);
 
-    try {
-      await deletePresetItem({ channelId, presetCategoryId, presetItemId });
-      // 업데이트된 아이템 리스트 조회
-      await getPresetData();
-    } catch (error) {
-      console.error('프리셋 아이템 삭제 실패: ', error);
-    }
-  };
+      try {
+        await deletePresetItem({ channelId, presetCategoryId, presetItemId });
+        // 업데이트된 아이템 리스트 조회
+        await getPresetData();
+      } catch (error) {
+        console.error('프리셋 아이템 삭제 실패: ', error);
+      }
+    },
+    [setDeleteButtonStates, deletePresetItem, getPresetData]
+  );
 
   const handleBack = () => {
     navigate(-1);
   };
 
-  const handleTabChange = (value: string) => {
-    setActiveTab(value);
-    window.scrollTo({
-      top: 0,
-    });
-  };
+  const handleTabChange = useCallback(
+    (value: string) => {
+      setActiveTab(value);
+      window.scrollTo({
+        top: 0,
+      });
+    },
+    [setActiveTab]
+  );
 
-  const handleCateTabChange = (value: string) => {
-    setCateActiveTab(value);
-    window.scrollTo({
-      top: 0,
-    });
-  };
+  const handleCateTabChange = useCallback(
+    (value: string) => {
+      setCateActiveTab(value);
+      window.scrollTo({
+        top: 0,
+      });
+    },
+    [setCateActiveTab]
+  );
+
+  const handleInputCateClick = useCallback((cate: string, cateId: number) => {
+    setActiveInputCate(cate);
+    setActiveInputCateId(cateId);
+  }, []);
+
+  const handleInputChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    if (value.length <= INPUT_VALIDATION.preset.maxLength) {
+      setInputVal(value);
+    }
+  }, []);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === 'Enter' && inputVal.trim()) {
+        handleAddInput(inputVal, activeInputCateId);
+        setInputVal('');
+      }
+    },
+    [handleAddInput]
+  );
+
+  const handleIconClick = useCallback(() => {
+    if (inputVal.trim()) {
+      handleAddInput(inputVal, activeInputCateId);
+      setInputVal('');
+    }
+  }, []);
 
   return {
     handleAddInput,
@@ -115,6 +166,10 @@ const usePresetSetting = () => {
     handleBack,
     handleTabChange,
     handleCateTabChange,
+    handleInputCateClick,
+    handleInputChange,
+    handleKeyDown,
+    handleIconClick,
   };
 };
 

--- a/src/pages/group/PresetSettingPage.tsx
+++ b/src/pages/group/PresetSettingPage.tsx
@@ -8,25 +8,13 @@ import usePresetSetting from '@/hooks/usePresetSetting';
 import usePresetSettingStore from '@/store/usePresetSettingStore';
 import MetaTags from '@/components/common/metaTags/MetaTags';
 import { useParams } from 'react-router-dom';
+import { useMemo } from 'react';
 
 const PresetSettingPage = () => {
-  const {
-    categoryList,
-    activeTab,
-    // setActiveTab,
-    cateActiveTab,
-    // setCateActiveTab,
-    deleteButtonStates,
-    presetData,
-  } = usePresetSettingStore();
-  const {
-    handleAddInput,
-    handleSelectClick,
-    handleDeleteClick,
-    handleBack,
-    handleTabChange,
-    handleCateTabChange,
-  } = usePresetSetting();
+  const { categoryList, activeTab, cateActiveTab, deleteButtonStates, presetData } =
+    usePresetSettingStore();
+  const { handleSelectClick, handleDeleteClick, handleBack, handleTabChange, handleCateTabChange } =
+    usePresetSetting();
   const { channelId } = useParams();
 
   return (
@@ -41,7 +29,7 @@ const PresetSettingPage = () => {
         <Tab
           activeTab={activeTab}
           handleSetActiveTab={handleTabChange}
-          chargers={convertTabNameToChargers(PresetTabName)}
+          chargers={useMemo(() => convertTabNameToChargers(PresetTabName), [])}
         />
       </div>
       {activeTab === PresetTabName.USER_DATA ? (
@@ -58,7 +46,7 @@ const PresetSettingPage = () => {
             />
           </div>
           <div className='sticky bottom-0 bg-[#fff]'>
-            <PresetAddInput categoryList={categoryList} handleAddInput={handleAddInput} />
+            <PresetAddInput categoryList={categoryList} />
           </div>
         </>
       ) : (


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

- 프리셋 설정 페이지 성능 최적화

## 📌 이슈 넘버

- #46 

## 📝 작업 내용
- React.memo, useCallback 사용하여 최적화
- 리팩토링
  - 클릭한 아이템 초기화 처리
  - 하위 컴포넌트 함수 hook 으로 이동
  - 하위 컴포넌트 React.FC 삭제

## 📸 스크린샷(선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
