### PR TITLE
Feature/#93 - 이용약관&개인정보 처리방침 버튼 추가

### DIFF
--- a/src/components/my/AccountMenuItem/AccountMenuItem.tsx
+++ b/src/components/my/AccountMenuItem/AccountMenuItem.tsx
@@ -26,6 +26,11 @@ const AccountMenuItem = forwardRef<HTMLDivElement, AccountMenuItemProps>(
               <ArrowRightIcon className='text-gray3' />
             </div>
           )}
+          {(iconType === 'terms' || iconType === 'course') && (
+            <div className='' onClick={handleClick}>
+              <ArrowRightIcon className='text-gray3' />
+            </div>
+          )}
         </div>
       </div>
     );

--- a/src/hooks/useAccountManage.ts
+++ b/src/hooks/useAccountManage.ts
@@ -23,12 +23,23 @@ export const useAccountManage = () => {
     setShowAlert(true);
   };
 
+  const handleNotice = (iconType: string) => {
+    if (iconType === 'terms') {
+      window.location.href =
+        'https://powerful-net-950.notion.site/180d58761b88807192e4f52d7e04e9c6?pvs=4';
+    } else {
+      window.location.href =
+        'https://powerful-net-950.notion.site/180d58761b8880eea920dc70361ddfb8?pvs=4';
+    }
+  };
+
   return {
     showAlert,
     setShowAlert,
     handleBack,
     handleLogout,
     handleLeave,
+    handleNotice,
     onConfirm,
   };
 };

--- a/src/pages/my/AccountManagePage.tsx
+++ b/src/pages/my/AccountManagePage.tsx
@@ -6,8 +6,15 @@ import MetaTags from '@/components/common/metaTags/MetaTags';
 import { useParams } from 'react-router-dom';
 
 const AccountManagePage = () => {
-  const { showAlert, setShowAlert, handleBack, handleLogout, handleLeave, onConfirm } =
-    useAccountManage();
+  const {
+    showAlert,
+    setShowAlert,
+    handleBack,
+    handleLogout,
+    handleLeave,
+    handleNotice,
+    onConfirm,
+  } = useAccountManage();
   const { channelId } = useParams();
 
   return (
@@ -25,6 +32,16 @@ const AccountManagePage = () => {
         onConfirm={handleLogout}
         open={showAlert}
         onOpenChange={setShowAlert}
+      />
+      <AccountMenuItem
+        label='이용약관'
+        iconType='terms'
+        handleClick={() => handleNotice('terms')}
+      />
+      <AccountMenuItem
+        label='개인정보 처리방침'
+        iconType='course'
+        handleClick={() => handleNotice('course')}
       />
       <AccountMenuItem label='탈퇴하기' iconType='탈퇴' handleClick={handleLeave} />
     </div>


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

> 계정 관리 페이지에 이용약관&개인정보 처리방침 버튼 추가

## 📌 이슈 넘버

- [ ] #96 

## 📝 작업 내용

## 📸 스크린샷(선택)

![image](https://github.com/user-attachments/assets/90c4ffd5-d249-429c-9a9f-b9d81b0fddb1)

- [https://powerful-net-950.notion.site/180d58761b88807192e4f52d7e04e9c6?pvs=4](url)
- [https://powerful-net-950.notion.site/180d58761b8880eea920dc70361ddfb8?pvs=4](url)

해당 노션 페이지로 이동하게했습니다.

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
