### PR TITLE
[Fix] FCM SDK 초기화 실패시 렌더링이 되지 않는 버그 수정

### DIFF
--- a/src/utils/fcm.ts
+++ b/src/utils/fcm.ts
@@ -1,5 +1,5 @@
 import { initializeApp } from 'firebase/app';
-import { getMessaging, getToken, Messaging } from 'firebase/messaging';
+import { getMessaging, getToken, Messaging, isSupported } from 'firebase/messaging';
 
 const firebaseConfig = {
   apiKey: import.meta.env.VITE_API_KEY,
@@ -11,33 +11,45 @@ const firebaseConfig = {
 };
 
 const app = initializeApp(firebaseConfig);
-const messaging: Messaging = getMessaging(app);
 
-export const requestForToken = () => {
-  return getToken(messaging, { vapidKey: import.meta.env.VITE_VAPID_KEY })
-    .then((currentToken: string) => {
-      if (currentToken) {
-        return currentToken;
-      } else {
-        console.log('No registration token available. Request permission to generate one.');
-        return null;
-      }
-    })
-    .catch((err: Error) => {
-      console.log('An error occurred while retrieving token - ' + err);
+// Firebase Messaging 지원 여부 확인 후 초기화
+let messaging: Messaging | null = null;
+
+(async () => {
+  if (typeof window !== 'undefined' && (await isSupported())) {
+    messaging = getMessaging(app);
+  } else {
+    console.warn('Firebase Messaging is not supported in this environment.');
+  }
+})();
+
+export const requestForToken = async (): Promise<string | null> => {
+  if (!messaging) {
+    console.warn('Messaging instance is not available.');
+    return null;
+  }
+
+  try {
+    const currentToken = await getToken(messaging, { vapidKey: import.meta.env.VITE_VAPID_KEY });
+    if (currentToken) {
+      return currentToken;
+    } else {
+      console.log('No registration token available. Request permission to generate one.');
       return null;
-    });
+    }
+  } catch (err) {
+    console.error('An error occurred while retrieving token:', err);
+    return null;
+  }
 };
 
 // 기기 유형 확인
 const getPlatformType = (): string => {
+  if (typeof window === 'undefined') return 'UNKNOWN'; // SSR 방지
+
   const userAgent = navigator.userAgent.toLowerCase();
-  if (/android/i.test(userAgent)) {
-    return 'ANDROID';
-  }
-  if (/iphone|ipad|ipod/i.test(userAgent)) {
-    return 'IOS';
-  }
+  if (/android/i.test(userAgent)) return 'ANDROID';
+  if (/iphone|ipad|ipod/i.test(userAgent)) return 'IOS';
   return 'PC';
 };
 
@@ -45,6 +57,11 @@ export const setupPushNotifications = async (): Promise<{
   token: string;
   platformType: string;
 } | null> => {
+  if (typeof window === 'undefined') {
+    console.warn('Push notifications cannot be set up in a server environment.');
+    return null;
+  }
+
   const permission = await Notification.requestPermission();
   if (permission === 'granted') {
     const token = await requestForToken();


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

> utils/fcm.ts : FCM SDK 초기화 실패 시 에러 핸들링

## 📌 이슈 넘버

- #150 

## 📝 작업 내용
- messaing을 바로 초기화하지 않음
- 초기화 할 수 있는 환경인지 확인
- 브라우저 환경이 아니거나 FCM이 지원되지 않는 환경이라면
- 경고 메세지를 출력하고 FCM SDK 초기화를 하지 않음 => FCM 이용 불가
- 네트워크로 접속해도 랜딩 페이지 출력

## 📸 스크린샷(선택)
![image](https://github.com/user-attachments/assets/c2bf60ba-d84e-4006-9ee1-57bb054957a1)


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
