### PR TITLE
Feature/#163 - accessToken 저장소 localStorage 로 변경

### DIFF
--- a/src/components/PrivateRouter.tsx
+++ b/src/components/PrivateRouter.tsx
@@ -6,7 +6,7 @@ interface PrivateRouterProps {
 }
 
 const PrivateRouter: React.FC<PrivateRouterProps> = ({ children }) => {
-  const token = sessionStorage.getItem('access_token');
+  const token = localStorage.getItem('access_token');
 
   if (!token) {
     return <Navigate to='/' replace />;

--- a/src/components/home/HouseworkList/HouseworkList.stories.ts
+++ b/src/components/home/HouseworkList/HouseworkList.stories.ts
@@ -1,7 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import HouseworkList, { HouseworkListProps } from '@/components/home/HouseworkList/HouseworkList';
 import { fn } from '@storybook/test';
-import { DUMMY_HOUSEWORKS } from '@/mock/mockHomePage';
 
 const meta = {
   title: 'components/home/HouseworkList',
@@ -15,7 +14,6 @@ type Story = StoryObj<HouseworkListProps>;
 
 export const Default: Story = {
   args: {
-    items: DUMMY_HOUSEWORKS,
     handleAction: fn(houseworkId => {
       console.log('Action triggered for housework:', houseworkId);
     }),

--- a/src/hooks/useAccountManage.ts
+++ b/src/hooks/useAccountManage.ts
@@ -13,7 +13,7 @@ export const useAccountManage = () => {
   };
 
   const handleLogout = () => {
-    sessionStorage.removeItem('access_token');
+    localStorage.removeItem('access_token');
     navigate('/');
   };
 

--- a/src/hooks/useLanding.ts
+++ b/src/hooks/useLanding.ts
@@ -11,7 +11,7 @@ export const useLanding = () => {
     const checkInitialState = async () => {
       const accessToken = new URLSearchParams(location.search).get('access_token');
       if (accessToken) {
-        sessionStorage.setItem('access_token', accessToken);
+        localStorage.setItem('access_token', accessToken);
 
         await initNotification();
 
@@ -24,7 +24,7 @@ export const useLanding = () => {
       }
     };
 
-    if (sessionStorage.getItem('access_token')) {
+    if (localStorage.getItem('access_token')) {
       navigate('/group-select');
       return;
     }

--- a/src/hooks/useLeave.ts
+++ b/src/hooks/useLeave.ts
@@ -17,7 +17,7 @@ export const useLeave = () => {
   const handleDone = async () => {
     try {
       await deleteUser();
-      sessionStorage.removeItem('access_token');
+      localStorage.removeItem('access_token');
       navigate('/');
     } catch (error) {
       console.error('회원 탈퇴 실패:', error);

--- a/src/pages/ErrorPage.tsx
+++ b/src/pages/ErrorPage.tsx
@@ -7,7 +7,7 @@ import useDevicePadding from '@/hooks/useDevicePadding';
 const ErrorPage = () => {
   const navigate = useNavigate();
   const handleClick = () => {
-    sessionStorage.getItem('access_token') ? navigate('/group-select') : navigate('/');
+    localStorage.getItem('access_token') ? navigate('/group-select') : navigate('/');
   };
   const paddingClass = useDevicePadding();
 

--- a/src/services/axiosInstance.ts
+++ b/src/services/axiosInstance.ts
@@ -13,7 +13,7 @@ export const axiosInstance = axios.create({
 
 axiosInstance.interceptors.request.use(
   config => {
-    const token = sessionStorage.getItem('access_token');
+    const token = localStorage.getItem('access_token');
     if (token) {
       config.headers.Authorization = `Bearer ${token}`;
     }


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

- accessToken 저장소 localStorage 로 변경

## 📌 이슈 넘버

- #163 

## 📝 작업 내용
- 소셜로그인 토큰 중복 이슈로인해 카카오 로그인하나만 유지되면서,
sessionStorage 을 사용할 필요성이 사라져서 localStorage 로 변경

## 📸 스크린샷(선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
